### PR TITLE
Add a BMx280 hardware test and some smaller adjustments

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
         <!-- JAVA COMPILER VERSIONS -->
-        <java.version>24</java.version>
+        <java.version>21</java.version>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
 
@@ -63,6 +63,11 @@
         <dependency>
             <groupId>com.pi4j</groupId>
             <artifactId>pi4j-plugin-gpiod</artifactId>
+            <version>${pi4j.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-linuxfs</artifactId>
             <version>${pi4j.version}</version>
         </dependency>
 

--- a/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverFakeI2cTest.java
+++ b/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverFakeI2cTest.java
@@ -4,7 +4,7 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertThrows;
 
-public class Bmx280DriverTest {
+public class Bmx280DriverFakeI2cTest {
 
     @Test
     public void testBmx280DriverUnrecognizedChipId() {

--- a/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverI2cTest.java
+++ b/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverI2cTest.java
@@ -1,0 +1,43 @@
+package com.pi4j.driver.sensor.bmx280;
+
+import com.pi4j.Pi4J;
+import com.pi4j.context.Context;
+import com.pi4j.io.i2c.I2C;
+import com.pi4j.io.i2c.I2CConfigBuilder;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * If a BME 280 configured to the BMP 280 address or a BMP 280 is connected to i2c bus 1,
+ * this test will perform a measurement and check that the values are in a reasonable range.
+ */
+public class Bmx280DriverI2cTest {
+
+    static final int BUS = 1;
+    static final int ADDRESS = Bmx280Driver.ADDRESS_BMP_280;
+
+    Context pi4j = Pi4J.newAutoContext();
+    I2C i2c = pi4j.create(I2CConfigBuilder.newInstance(pi4j).bus(BUS).device(ADDRESS));
+
+
+    @Test
+    public void testBasicMeasurementWorks() {
+        Bmx280Driver driver;
+        try {
+            driver = new Bmx280Driver(i2c);
+        } catch (RuntimeException e) {
+            Assumptions.abort("BMx280 not found on i2c bus " + BUS + " address " + ADDRESS);
+            return;
+        }
+
+        Bmx280Driver.Measurement measurement = driver.readMeasurement();
+
+        assertTrue(measurement.getTemperature() > 0);
+        assertTrue(measurement.getTemperature() < 50);
+        assertTrue(measurement.getPressure() > 90_000);
+        assertTrue(measurement.getPressure() < 110_000);
+    }
+
+}

--- a/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverI2cTest.java
+++ b/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverI2cTest.java
@@ -2,6 +2,7 @@ package com.pi4j.driver.sensor.bmx280;
 
 import com.pi4j.Pi4J;
 import com.pi4j.context.Context;
+import com.pi4j.exception.Pi4JException;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfigBuilder;
 import org.junit.jupiter.api.Assumptions;
@@ -19,7 +20,7 @@ public class Bmx280DriverI2cTest {
     static final int ADDRESS = Bmx280Driver.ADDRESS_BMP_280;
 
     static final Context pi4j = Pi4J.newAutoContext();
-    
+
     @Test
     public void testBasicMeasurementWorks() {
         Bmx280Driver driver = createDriverOrAbort();
@@ -36,7 +37,7 @@ public class Bmx280DriverI2cTest {
         try {
             I2C i2c = pi4j.create(I2CConfigBuilder.newInstance(pi4j).bus(BUS).device(ADDRESS));
             return new Bmx280Driver(i2c);
-        } catch (RuntimeException e) {
+        } catch (Pi4JException e) {
             Assumptions.abort("BMx280 not found on i2c bus " + BUS + " address " + ADDRESS);
             throw new RuntimeException(e);
         }

--- a/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverI2cTest.java
+++ b/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverI2cTest.java
@@ -18,19 +18,11 @@ public class Bmx280DriverI2cTest {
     static final int BUS = 1;
     static final int ADDRESS = Bmx280Driver.ADDRESS_BMP_280;
 
-    Context pi4j = Pi4J.newAutoContext();
-    I2C i2c = pi4j.create(I2CConfigBuilder.newInstance(pi4j).bus(BUS).device(ADDRESS));
-
-
+    static final Context pi4j = Pi4J.newAutoContext();
+    
     @Test
     public void testBasicMeasurementWorks() {
-        Bmx280Driver driver;
-        try {
-            driver = new Bmx280Driver(i2c);
-        } catch (RuntimeException e) {
-            Assumptions.abort("BMx280 not found on i2c bus " + BUS + " address " + ADDRESS);
-            return;
-        }
+        Bmx280Driver driver = createDriverOrAbort();
 
         Bmx280Driver.Measurement measurement = driver.readMeasurement();
 
@@ -39,5 +31,16 @@ public class Bmx280DriverI2cTest {
         assertTrue(measurement.getPressure() > 90_000);
         assertTrue(measurement.getPressure() < 110_000);
     }
+
+    Bmx280Driver createDriverOrAbort() {
+        try {
+            I2C i2c = pi4j.create(I2CConfigBuilder.newInstance(pi4j).bus(BUS).device(ADDRESS));
+            return new Bmx280Driver(i2c);
+        } catch (RuntimeException e) {
+            Assumptions.abort("BMx280 not found on i2c bus " + BUS + " address " + ADDRESS);
+            throw new RuntimeException(e);
+        }
+    }
+
 
 }


### PR DESCRIPTION
- Rename readMeasurements to readMeasurement for consistency with the corresponding data class.
- Migrate delays to Instant for consistency with other devices that will have sub-millisecond delays
- Add a linux fs dependency so the test actually passes on modern hardware
- Reduce java requirement to 21 to match home page installation instructions
