### PR TITLE
Restructure Tests

### DIFF
--- a/src/test/java/com/pi4j/driver/sensor/bmx280/AbstractBmx280DriverTest.java
+++ b/src/test/java/com/pi4j/driver/sensor/bmx280/AbstractBmx280DriverTest.java
@@ -1,0 +1,32 @@
+package com.pi4j.driver.sensor.bmx280;
+
+import com.pi4j.Pi4J;
+import com.pi4j.context.Context;
+import com.pi4j.exception.Pi4JException;
+import com.pi4j.io.i2c.I2C;
+import com.pi4j.io.i2c.I2CConfigBuilder;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Common tests that work for spi, i2c and fake drivers.
+ */
+abstract class AbstractBmx280DriverTest {
+
+    @Test
+    public void testBasicMeasurementWorks() {
+        Bmx280Driver driver = createDriver();
+
+        Bmx280Driver.Measurement measurement = driver.readMeasurement();
+
+        assertTrue(measurement.getTemperature() > 0);
+        assertTrue(measurement.getTemperature() < 50);
+        assertTrue(measurement.getPressure() > 90_000);
+        assertTrue(measurement.getPressure() < 110_000);
+    }
+
+
+    abstract Bmx280Driver createDriver();
+
+}

--- a/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverFakeI2cTest.java
+++ b/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverFakeI2cTest.java
@@ -1,21 +1,33 @@
 package com.pi4j.driver.sensor.bmx280;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.junit.jupiter.api.Test;
 
-import static org.junit.jupiter.api.Assertions.assertThrows;
-
-public class Bmx280DriverFakeI2cTest {
+/**
+ * Runs common tests from the base class and additional tests depending on a specific fake setup.
+ */
+public class Bmx280DriverFakeI2cTest extends AbstractBmx280DriverTest {
 
     @Test
-    public void testBmx280DriverUnrecognizedChipId() {
-        FakeI2CRegisterDataReaderWriter access = new FakeI2CRegisterDataReaderWriter(
-                FakeI2CRegisterDataReaderWriter.READ, Bmp280Constants.CHIP_ID, 123
-        );
-
-        assertThrows(
-                IllegalStateException.class,
-                () -> new Bmx280Driver(access),
-                "Unrecognized chip ID: 123");
+    public void testChipId() {
+        Bmx280Driver driver = createDriver();
+        assertEquals(Bmx280Driver.SensorType.BME280, driver.getSensorType());
     }
 
+    @Override
+    Bmx280Driver createDriver() {
+        FakeI2CRegisterDataReaderWriter fakeI2c =  new FakeI2CRegisterDataReaderWriter();
+
+        // Chip id
+        fakeI2c.writeRegister(Bmp280Constants.CHIP_ID, Bmp280Constants.ID_VALUE_BME);
+
+        // Calibration data
+        fakeI2c.writeRegister(0x88, new byte[]{0, 110, -114, 103, 50, 0, 67, -111, 102, -42, -48, 11, -61, 27, 44, 0, -7, -1, -76, 45, -24, -47, -120, 19});
+        fakeI2c.writeRegister(0xe0, new byte[]{0, 110, 1, 0, 19, 39, 3, 30, 4, 65, -1, -1, -1, -1, -1, -1});
+
+        // Measurement data
+        fakeI2c.writeRegister(0xf7, new byte[]{86, -61, 0, 126, -63, 0, 123, 82, -128});
+
+        return new Bmx280Driver(fakeI2c);
+    }
 }

--- a/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverI2cTest.java
+++ b/src/test/java/com/pi4j/driver/sensor/bmx280/Bmx280DriverI2cTest.java
@@ -6,34 +6,20 @@ import com.pi4j.exception.Pi4JException;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CConfigBuilder;
 import org.junit.jupiter.api.Assumptions;
-import org.junit.jupiter.api.Test;
-
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * If a BME 280 configured to the BMP 280 address or a BMP 280 is connected to i2c bus 1,
- * this test will perform a measurement and check that the values are in a reasonable range.
+ * Runs tests if a BME 280 configured to the BMP 280 address or a BMP 280 is connected to i2c bus 1;
+ * aborts otherwise.
  */
-public class Bmx280DriverI2cTest {
+public class Bmx280DriverI2cTest extends AbstractBmx280DriverTest {
 
     static final int BUS = 1;
     static final int ADDRESS = Bmx280Driver.ADDRESS_BMP_280;
 
     static final Context pi4j = Pi4J.newAutoContext();
 
-    @Test
-    public void testBasicMeasurementWorks() {
-        Bmx280Driver driver = createDriverOrAbort();
-
-        Bmx280Driver.Measurement measurement = driver.readMeasurement();
-
-        assertTrue(measurement.getTemperature() > 0);
-        assertTrue(measurement.getTemperature() < 50);
-        assertTrue(measurement.getPressure() > 90_000);
-        assertTrue(measurement.getPressure() < 110_000);
-    }
-
-    Bmx280Driver createDriverOrAbort() {
+    @Override
+    Bmx280Driver createDriver() {
         try {
             I2C i2c = pi4j.create(I2CConfigBuilder.newInstance(pi4j).bus(BUS).device(ADDRESS));
             return new Bmx280Driver(i2c);
@@ -42,6 +28,4 @@ public class Bmx280DriverI2cTest {
             throw new RuntimeException(e);
         }
     }
-
-
 }

--- a/src/test/java/com/pi4j/driver/sensor/bmx280/FakeI2CRegisterDataReaderWriter.java
+++ b/src/test/java/com/pi4j/driver/sensor/bmx280/FakeI2CRegisterDataReaderWriter.java
@@ -6,29 +6,17 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Fake I2C register access implementation that can play back / expect a given communication
- * pattern.
- * <p>
- * For the given test, a mock would have been more straightforward, but I didn't want to pull in
- * additional dependencies.
+ * Fake I2C register access implementation that just stores the register values as sent.
+ * Regular register read and write operations can be used in tests to set expected output data and
  */
 public class FakeI2CRegisterDataReaderWriter implements I2CRegisterDataReaderWriter {
 
-    public final static int READ = -1;
-    public final static int WRITE = -2;
-
-    final int[] expectedCommunication;
-    private int position = 0;
-    private byte[] buf = new byte[1];
-
-    public FakeI2CRegisterDataReaderWriter(int... expectedCommunication) {
-        this.expectedCommunication = expectedCommunication;
-    }
+    // Allow tests direct access
+    public final byte[] registerValues = new byte[256];
 
     @Override
     public int readRegister(int index) {
-        readRegister(index, buf, 0, 1);
-        return buf[0] & 255;
+        return registerValues[index] & 255;
     }
 
     @Override
@@ -38,35 +26,19 @@ public class FakeI2CRegisterDataReaderWriter implements I2CRegisterDataReaderWri
 
     @Override
     public int readRegister(int register, byte[] data, int offset, int length) {
-        assertEquals(expectedCommunication[position++], READ, "READ marker expected");
-        assertEquals(expectedCommunication[position++], register, "register expected");
-
-        for (int i = 0; i < length; i++) {
-            int input = expectedCommunication[position++];
-            assertTrue (input >= 0, "Read data expected");
-            data[offset + i] = (byte) input;
-        }
-
+        System.arraycopy(registerValues, register, data, offset, length);
         return length;
     }
 
     @Override
     public int writeRegister(int register, byte value) {
-        buf[0] = value;
-        writeRegister(register, buf, 0, 1);
+        registerValues[register] = value;
         return 1;
     }
 
     @Override
     public int writeRegister(int register, byte[] data, int offset, int length) {
-        assertEquals(expectedCommunication[position++], WRITE, "WRITE marker expected");
-        assertEquals(expectedCommunication[position++], register, "register expected");
-
-        for (int i = 0; i < length; i++) {
-            int input = expectedCommunication[position++];
-            assertEquals(input, data[offset + i] & 0xff, input);
-        }
-
+        System.arraycopy(data, offset, registerValues, register, length);
         return length;
     }
 


### PR DESCRIPTION
- Simplify the fake IO to just be a set of registers
- Fill the registers with some reasonable data for a slightly extended fake test
- Share common tests between fake and real device using an abstract base class

My first approach was to just have one test class and fall back to the fake if the hw is not available, but that would make it hard to see whether actual hardware tests run or not. And I think the fake tests should be run in any case, so one doesn't need to disconnect the hardware to make sure they still run as expected

I considered using parameterized test to run all configurations, but an abstract base class seemed more straightforward here.