### PR TITLE
Remove the explicit ChipSelect DigitalOutput for BMx280 SPI

### DIFF
--- a/src/main/java/com/pi4j/driver/sensor/bmx280/Bmx280Driver.java
+++ b/src/main/java/com/pi4j/driver/sensor/bmx280/Bmx280Driver.java
@@ -16,7 +16,6 @@
 
 package com.pi4j.driver.sensor.bmx280;
 
-import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.i2c.I2C;
 import com.pi4j.io.i2c.I2CRegisterDataReaderWriter;
 import com.pi4j.io.spi.Spi;

--- a/src/main/java/com/pi4j/driver/sensor/bmx280/SpiRegisterAccess.java
+++ b/src/main/java/com/pi4j/driver/sensor/bmx280/SpiRegisterAccess.java
@@ -15,7 +15,6 @@
  */
 package com.pi4j.driver.sensor.bmx280;
 
-import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.i2c.I2CRegisterDataReaderWriter;
 import com.pi4j.io.spi.Spi;
 


### PR DESCRIPTION
In the current state of Pi4j it will always be redundant with the SPI CS, and in the future, if the integrated CS can be disabled, it would still be cleaner to add a custom SPI class that wraps pi4j spi, adding custom CS output pin support