### PR TITLE
Support different display heights in the st7789 driver

### DIFF
--- a/src/main/java/com/pi4j/driver/display/DisplayInfo.java
+++ b/src/main/java/com/pi4j/driver/display/DisplayInfo.java
@@ -4,7 +4,7 @@ public class DisplayInfo {
 
     private final int width;
     private final int height;
-    private PixelFormat pixelFormat;
+    private final PixelFormat pixelFormat;
 
     public DisplayInfo(int width, int height, PixelFormat pixelFormat) {
         this.width = width;
@@ -12,15 +12,15 @@ public class DisplayInfo {
         this.pixelFormat = pixelFormat;
     }
 
-    int getWidth() {
+    public int getWidth() {
         return width;
     } // In pixel
 
-    int getHeight() {
+    public int getHeight() {
         return height;
     }
 
-    PixelFormat getPixelFormat() {
+    public PixelFormat getPixelFormat() {
         return pixelFormat;
     }
 }

--- a/src/main/java/com/pi4j/driver/display/DisplayInfo.java
+++ b/src/main/java/com/pi4j/driver/display/DisplayInfo.java
@@ -12,10 +12,12 @@ public class DisplayInfo {
         this.pixelFormat = pixelFormat;
     }
 
+    /** The width of the display in pixel. */
     public int getWidth() {
         return width;
-    } // In pixel
+    }
 
+    /** The height of the display in pixel. */
     public int getHeight() {
         return height;
     }

--- a/src/main/java/com/pi4j/driver/display/GraphicsDisplayDriver.java
+++ b/src/main/java/com/pi4j/driver/display/GraphicsDisplayDriver.java
@@ -1,7 +1,5 @@
 package com.pi4j.driver.display;
 
-import java.io.IOException;
-
 public interface GraphicsDisplayDriver {
 
     DisplayInfo getDisplayInfo();

--- a/src/main/java/com/pi4j/driver/display/GraphicsDisplayDriver.java
+++ b/src/main/java/com/pi4j/driver/display/GraphicsDisplayDriver.java
@@ -6,5 +6,5 @@ public interface GraphicsDisplayDriver {
 
     DisplayInfo getDisplayInfo();
 
-    void setPixels(int x, int y, int width, int height, byte[] data) throws IOException;
+    void setPixels(int x, int y, int width, int height, byte[] data);
 }

--- a/src/test/java/com/pi4j/driver/display/FakeDisplayDriver.java
+++ b/src/test/java/com/pi4j/driver/display/FakeDisplayDriver.java
@@ -28,7 +28,7 @@ public class FakeDisplayDriver implements GraphicsDisplayDriver {
     }
 
     @Override
-    public void setPixels(int x, int y, int width, int height, byte[] data) throws IOException {
+    public void setPixels(int x, int y, int width, int height, byte[] data) {
         log.trace("setPixels: {} {} {} {}", x, y, width, height);
         log.trace("\t" + HexFormat.of().formatHex(data));
         this.data = data;


### PR DESCRIPTION
Tested with the 1.3 inch Waveshare lcd hat and a 2 inch "seengreat" 320x240 display

Includes some cleanup: 
- don't declare unchecked exceptions
- de-duplicate address command code
- make some fields final
- make displayinfo getters public, so they can actually be used in client code. 