### PR TITLE
Enable PixelFormat to write rgb24 ints into a device format byte buffer 

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/PixelFormat.java
+++ b/src/main/java/com/pi4j/drivers/display/PixelFormat.java
@@ -2,6 +2,49 @@ package com.pi4j.drivers.display;
 
 public enum PixelFormat {
 
-    RGB_444, // 12-bit color format with 4 bits for each color channel (red, green, blue)
-    RGB_565 // 16-bit color format that uses 5 bits for red, 6 bits for green, and 5 bits for blue
+    RGB_444( 4, 4, 4), // 12-bit color format with 4 bits for each color channel (red, green, blue)
+    RGB_565( 5, 6, 5); // 16-bit color format that uses 5 bits for red, 6 bits for green, and 5 bits for blue
+
+    private final int redBits;
+    private final int greenBits;
+    private final int blueBits;
+
+    PixelFormat(int redBits, int greenBits, int blueBits) {
+        this.redBits = redBits;
+        this.greenBits = greenBits;
+        this.blueBits = blueBits;
+    }
+
+    // The total number of bits used by this format.
+    public int getBitCount() {
+        return redBits + greenBits + blueBits;
+    }
+
+    /** Writes count bits (up to 24) into the given buffer at the given bit offset. */
+    private void writeBits(int value, int count, byte[] buffer, int bitOffset) {
+        int byteOffset = bitOffset / 8;
+        bitOffset %= 8;
+        int mask = ((1 << count) - 1) << (32 - count - bitOffset);
+
+        value <<= (32 - count - bitOffset);
+        while (mask != 0) {
+            buffer[byteOffset] = (byte) ((buffer[byteOffset] & ~(mask >> 24)) | (value >> 24));
+            byteOffset++;
+            value <<= 8;
+            mask <<= 8;
+        }
+    }
+    /**
+     * Writes a 24-bit RGB value into the given buffer in this pixel format at the given *bit* offset,
+     * returning the number of bits written.
+     */
+    public int writeRgb(int rgb, byte[] buffer, int bitOffset) {
+        int red = (rgb >> (24 - redBits)) & 0xff;
+        int green = (rgb >> (16 - greenBits)) & 0xff;
+        int blue = (rgb >> (8 - blueBits)) & 0xff;
+        int count = redBits + greenBits + blueBits;
+
+        writeBits((red << (greenBits + blueBits)) | (green << (blueBits)) | blue, count, buffer, bitOffset);
+        return count;
+    }
 }

--- a/src/test/java/com/pi4j/drivers/display/PixelFormatTest.java
+++ b/src/test/java/com/pi4j/drivers/display/PixelFormatTest.java
@@ -1,0 +1,24 @@
+package com.pi4j.drivers.display;
+
+
+import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+public class PixelFormatTest {
+
+    @Test
+    public void testRgb444() {
+        byte[] target = new byte[3];
+
+        PixelFormat format = PixelFormat.RGB_444;
+
+        int offset = 0;
+        offset += format.writeRgb(0x0aabbcc, target, offset);
+        offset += format.writeRgb(0x0112233, target, offset);
+
+        assertEquals((byte) 0xab, target[0]);
+        assertEquals((byte) 0xc1, target[1]);
+        assertEquals((byte) 0x23, target[2]);
+    }
+
+}


### PR DESCRIPTION
This should allow us to simplify data transfers from the display component to the driver.