### PR TITLE
Fix and expand pixelformat support

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/PixelFormat.java
+++ b/src/main/java/com/pi4j/drivers/display/PixelFormat.java
@@ -5,22 +5,37 @@ public enum PixelFormat {
     RGB_444( 4, 4, 4), // 12-bit color format with 4 bits for each color channel (red, green, blue)
     RGB_565( 5, 6, 5); // 16-bit color format that uses 5 bits for red, 6 bits for green, and 5 bits for blue
 
-    private final int redBits;
-    private final int greenBits;
-    private final int blueBits;
+    private final int redBitCount;
+    private final int greenBitCount;
+    private final int blueBitCount;
 
-    PixelFormat(int redBits, int greenBits, int blueBits) {
-        this.redBits = redBits;
-        this.greenBits = greenBits;
-        this.blueBits = blueBits;
+    private final int redMask;
+    private final int greenMask;
+    private final int blueMask;
+
+    PixelFormat(int redBitCount, int greenBitCount, int blueBitCount) {
+        this.redBitCount = redBitCount;
+        this.greenBitCount = greenBitCount;
+        this.blueBitCount = blueBitCount;
+
+        this.redMask = (1 << redBitCount) - 1;
+        this.greenMask = (1 << greenBitCount) - 1;
+        this.blueMask = (1 << blueBitCount) - 1;
     }
 
     // The total number of bits used by this format.
     int getBitCount() {
-        return redBits + greenBits + blueBits;
+        return redBitCount + greenBitCount + blueBitCount;
     }
 
-    /** Writes count bits (up to 24) into the given buffer at the given bit offset. */
+    /**
+     * Writes count bits (up to 24) into the given buffer at the given bit offset.
+     *
+     * @param value The value to write.
+     * @param count The number of bits (up to 24).
+     * @param buffer The buffer to write the bits to
+     * @param bitOffset The bit offset in the buffer
+     */
     private void writeBits(int value, int count, byte[] buffer, int bitOffset) {
         int byteOffset = bitOffset / 8;
         bitOffset %= 8;
@@ -35,17 +50,53 @@ public enum PixelFormat {
         }
     }
 
+    /** Converts a value from a 24 bit RGB integer value to "this" pixel format. */
+    int fromRgb(int rgb) {
+        int red = (rgb >> (24 - redBitCount)) & redMask;
+        int green = (rgb >> (16 - greenBitCount)) & greenMask;
+        int blue = (rgb >> (8 - blueBitCount)) & blueMask;
+        return (red << (greenBitCount + blueBitCount)) | (green << (blueBitCount)) | blue;
+    }
+
     /**
-     * Writes a 24-bit RGB value into the given buffer in this pixel format at the given *bit* offset,
+     * Writes a 24-bit RGB value into the given buffer in "this" pixel format at the given *bit* offset,
      * returning the number of bits written.
      */
     int writeRgb(int rgb, byte[] buffer, int bitOffset) {
-        int red = (rgb >> (24 - redBits)) & 0xff;
-        int green = (rgb >> (16 - greenBits)) & 0xff;
-        int blue = (rgb >> (8 - blueBits)) & 0xff;
-        int count = redBits + greenBits + blueBits;
-
-        writeBits((red << (greenBits + blueBits)) | (green << (blueBits)) | blue, count, buffer, bitOffset);
+        int count = redBitCount + greenBitCount + blueBitCount;
+        writeBits(fromRgb(rgb), count, buffer, bitOffset);
         return count;
+    }
+
+    /**
+     * Writes 24 bit integer RGB values from srcRgb to dst in "this" pixel format.
+     *
+     * @param srcRgb The source array with rgb values in 24 bit integers.
+     * @param srcOffset The start offset in the soruce array
+     * @param dst The destination buffer.
+     * @param dstBitOffset The bit offset in the desitination buffer.
+     * @param pixelCount The number of pixels to be transferred.
+     * @return The number of bits written.
+     */
+    int writeRgb(int[] srcRgb, int srcOffset, byte[] dst, int dstBitOffset, int pixelCount) {
+        int bitsWritten = 0;
+        for (int i = 0; i < pixelCount; i++) {
+            bitsWritten += writeRgb(srcRgb[srcOffset + i], dst, dstBitOffset + bitsWritten);
+        }
+        return bitsWritten;
+    }
+
+    /**
+     * Fills the dst array with pixels of the same 24 bit rgb color, converted to "this" format.
+     */
+    int fillRgb(byte[] dst, int dstBitOffset, int pixelCount, int rgb) {
+        int bitsWritten = 0;
+        int nativeColor = fromRgb(rgb);
+        int bitCount = getBitCount();
+        for (int i = 0; i < pixelCount; i++) {
+            writeBits(nativeColor, bitCount, dst, dstBitOffset + bitsWritten);
+            bitsWritten += bitCount;
+        }
+        return bitsWritten;
     }
 }

--- a/src/test/java/com/pi4j/drivers/display/PixelFormatTest.java
+++ b/src/test/java/com/pi4j/drivers/display/PixelFormatTest.java
@@ -7,7 +7,27 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 public class PixelFormatTest {
 
     @Test
-    public void testRgb444() {
+    public void testFromRgb444() {
+        assertEquals(0xabc, PixelFormat.RGB_444.fromRgb(0xaabbcc));
+        assertEquals(0xabc, PixelFormat.RGB_444.fromRgb(0xa0b0c0));
+        assertEquals(0xabc, PixelFormat.RGB_444.fromRgb(0xafbfcf));
+
+        assertEquals(0x000, PixelFormat.RGB_444.fromRgb(0));
+        assertEquals(0x888, PixelFormat.RGB_444.fromRgb(0x888888));
+        assertEquals(0xfff, PixelFormat.RGB_444.fromRgb(0xffffff));
+    }
+
+    @Test
+    public void testFromRgb565() {
+        assertEquals(0b11111_000000_11111, PixelFormat.RGB_565.fromRgb(0x0ff00ff));
+        assertEquals(0b11110_111100_11110, PixelFormat.RGB_565.fromRgb(0x0f0f0f0));
+
+        assertEquals(0, PixelFormat.RGB_565.fromRgb(0));
+        assertEquals(0b11111_111111_11111, PixelFormat.RGB_565.fromRgb(0xffffff));
+    }
+
+    @Test
+    public void testWriteRgb444() {
         byte[] target = new byte[3];
 
         PixelFormat format = PixelFormat.RGB_444;
@@ -24,7 +44,7 @@ public class PixelFormatTest {
 
 
     @Test
-    public void testRgb565() {
+    public void testWriteRgb565() {
         byte[] target = new byte[4];
 
         PixelFormat format = PixelFormat.RGB_565;
@@ -39,5 +59,64 @@ public class PixelFormatTest {
 
         assertEquals((byte) 0b11110_111, target[2]);
         assertEquals((byte) 0b100_11110, target[3]);
+    }
+
+    @Test
+    public void testWriteRgbArray444() {
+        byte[] target = new byte[6];
+
+        PixelFormat format = PixelFormat.RGB_444;
+
+        int offset = format.writeRgb(new int[] {0x0aabbcc, 0x0112233}, 0, target, 0, 2);
+
+        assertEquals(24, offset);
+        assertEquals((byte) 0xab, target[0]);
+        assertEquals((byte) 0xc1, target[1]);
+        assertEquals((byte) 0x23, target[2]);
+    }
+
+    @Test
+    public void testWriteRgbArray565() {
+        byte[] target = new byte[4];
+
+        PixelFormat format = PixelFormat.RGB_565;
+
+        int offset = format.writeRgb(new int[] {0x0ff00ff, 0x0f0f0f0}, 0, target, 0, 2);
+
+        assertEquals(32, offset);
+        assertEquals((byte) 0b11111_000, target[0]);
+        assertEquals((byte) 0b000_11111, target[1]);
+
+        assertEquals((byte) 0b11110_111, target[2]);
+        assertEquals((byte) 0b100_11110, target[3]);
+    }
+
+    @Test
+    public void testFillRgb444() {
+        byte[] target = new byte[3];
+
+        PixelFormat format = PixelFormat.RGB_444;
+
+        int offset = format.fillRgb(target, 0, 2, 0xaabbcc);
+
+        assertEquals(24, offset);
+        assertEquals((byte) 0xab, target[0]);
+        assertEquals((byte) 0xca, target[1]);
+        assertEquals((byte) 0xbc, target[2]);
+    }
+
+    @Test
+    public void testFillRgb565() {
+        byte[] target = new byte[4];
+
+        PixelFormat format = PixelFormat.RGB_565;
+
+        int offset = format.fillRgb(target, 0, 2, 0x0ff00ff);
+
+        assertEquals(32, offset);
+        assertEquals((byte) 0b11111_000, target[0]);
+        assertEquals((byte) 0b000_11111, target[1]);
+        assertEquals((byte) 0b11111_000, target[2]);
+        assertEquals((byte) 0b000_11111, target[3]);
     }
 }


### PR DESCRIPTION
The static bit masks were leaking, caught in added tests

Also added additional support so the BasicGraphicsImageComponent can be focussed on higher level stuff (e.g. buffering).

Keeping it package visible for now, so we don't lock ourselves into the current api state.

 