### PR TITLE
Switch the BaseGraphicDisplayComponent methods to use the generic PixelFormat transfer methods.

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/AwtGraphicsDisplayComponent.java
+++ b/src/main/java/com/pi4j/drivers/display/AwtGraphicsDisplayComponent.java
@@ -24,6 +24,5 @@ public class AwtGraphicsDisplayComponent extends BaseGraphicsDisplayComponent {
 
         int[] rgb888pixels = img.getRGB(0, 0, img.getWidth(), img.getHeight(), null, 0, img.getWidth());
         drawImage(0, 0, img.getWidth(), img.getHeight(), rgb888pixels);
-
     }
 }

--- a/src/main/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponent.java
+++ b/src/main/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponent.java
@@ -4,7 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BaseGraphicsDisplayComponent {
-    private static final int MAX_SPI_TRANSFER_SIZE = 65535;
+    private static final int MAX_SPI_TRANSFER_SIZE = 4000;
 
     private static Logger log = LoggerFactory.getLogger(BaseGraphicsDisplayComponent.class);
 
@@ -36,7 +36,10 @@ public class BaseGraphicsDisplayComponent {
         }
     }
 
-    public void fillRect(int x, int y, int width, int height, int rgb888) throws java.io.IOException {
+    public void fillRect(int x, int y, int width, int height, int rgb888) {
+        if (width <= 0 || height <= 0) {
+            return;
+        }
         PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
 
         int bitsPerRow = width * pixelFormat.getBitCount();

--- a/src/main/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponent.java
+++ b/src/main/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponent.java
@@ -4,13 +4,17 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BaseGraphicsDisplayComponent {
+    private static final int MAX_SPI_TRANSFER_SIZE = 65535;
 
     private static Logger log = LoggerFactory.getLogger(BaseGraphicsDisplayComponent.class);
 
     protected final GraphicsDisplayDriver driver;
+    private final byte[] spiBuffer;
 
     public BaseGraphicsDisplayComponent(GraphicsDisplayDriver driver) {
         this.driver = driver;
+        spiBuffer = new byte[Math.min(MAX_SPI_TRANSFER_SIZE,
+                (driver.getDisplayInfo().getHeight() * driver.getDisplayInfo().getWidth() * driver.getDisplayInfo().getPixelFormat().getBitCount() + 7) / 8)];
     }
 
     // it is possible that rgb888pixels contains more than will fit
@@ -19,21 +23,34 @@ public class BaseGraphicsDisplayComponent {
         log.debug("drawImage: {},{} \t {} x {} \t {}", x, y, width, height, rgb888pixels.length);
         PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
 
-        byte[] data = new byte[(width * pixelFormat.getBitCount() + 7) / 8];
+        int bitsPerRow = width * pixelFormat.getBitCount();
+        int bitOffset = 0;
         for (int i = 0; i < height; i++) {
-            pixelFormat.writeRgb(rgb888pixels, width * i, data, 0, width);
-            driver.setPixels(x, y + i, width, 1, data);
+            bitOffset += pixelFormat.writeRgb(rgb888pixels, width * i, spiBuffer, bitOffset, width);
+            // Transfer if the last row is reached or the next row would overflow the buffer.
+            if (i == height - 1 || bitOffset + bitsPerRow > spiBuffer.length * 8) {
+                int rows = bitOffset / bitsPerRow;
+                driver.setPixels(x, y + i + 1 - rows, width, rows, spiBuffer);
+                bitOffset = 0;
+            }
         }
     }
 
     public void fillRect(int x, int y, int width, int height, int rgb888) throws java.io.IOException {
         PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
 
-        byte[] data = new byte[(width * pixelFormat.getBitCount() + 7) / 8];
-        pixelFormat.fillRgb(data, 0, width, rgb888);
+        int bitsPerRow = width * pixelFormat.getBitCount();
+        int rowCount = spiBuffer.length * 8 / bitsPerRow;
 
-        for (int i = 0; i < height; i++) {
-            driver.setPixels(x, y + i, width, 1, data);
+        pixelFormat.fillRgb(spiBuffer, 0, width * rowCount, rgb888);
+
+        for (int i = 0; i < height; i += rowCount) {
+            driver.setPixels(
+                    x,
+                    y + i,
+                    width,
+                    Math.min(rowCount, height - i),
+                    spiBuffer);
         }
     }
 }

--- a/src/main/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponent.java
+++ b/src/main/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponent.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 public class BaseGraphicsDisplayComponent {
+    // TODO(https://github.com/Pi4J/pi4j/issues/475): Remove or update this limitation.
     private static final int MAX_SPI_TRANSFER_SIZE = 4000;
 
     private static Logger log = LoggerFactory.getLogger(BaseGraphicsDisplayComponent.class);

--- a/src/main/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponent.java
+++ b/src/main/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponent.java
@@ -16,140 +16,24 @@ public class BaseGraphicsDisplayComponent {
     // it is possible that rgb888pixels contains more than will fit
     // we will just ignore them
     public void drawImage(int x, int y, int width, int height, int[] rgb888pixels) {
-
         log.debug("drawImage: {},{} \t {} x {} \t {}", x, y, width, height, rgb888pixels.length);
-        int[] values = new int[width * height];
+        PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
 
-        for (int index = 0; index < values.length; index++) {
-
-            int alpha = (rgb888pixels[index] >> 24) & 0xff;
-            int red = (rgb888pixels[index] >> 16) & 0xff;
-            int green = (rgb888pixels[index] >> 8) & 0xff;
-            int blue = (rgb888pixels[index] >> 0) & 0xff;
-
-            switch (driver.getDisplayInfo().getPixelFormat()) {
-                case RGB_444:
-                    values[index] = rgb888toRgb444(red, green, blue);
-                    break;
-                case RGB_565:
-                    values[index] = rgb888toRgb565(red, green, blue);
-                    break;
-                default:
-                    throw new IllegalArgumentException(
-                            "Unsupported pixel format: " + driver.getDisplayInfo().getPixelFormat());
-            }
-        }
-
-        if (PixelFormat.RGB_444 == driver.getDisplayInfo().getPixelFormat()) {
-
-            byte[] data = pack12(values);
-            driver.setPixels(x, y, width, height, data);
-
-        } else if (PixelFormat.RGB_565 == driver.getDisplayInfo().getPixelFormat()) {
-
-            byte[] data = new byte[width * height * 16 / 8];
-
-            for (int index = 0; index < values.length; index++) {
-                data[2 * index] = (byte) (values[index] >> 8);
-                data[2 * index + 1] = (byte) values[index];
-            }
-
-            driver.setPixels(x, y, width, height, data);
+        byte[] data = new byte[(width * pixelFormat.getBitCount() + 7) / 8];
+        for (int i = 0; i < height; i++) {
+            pixelFormat.writeRgb(rgb888pixels, width * i, data, 0, width);
+            driver.setPixels(x, y + i, width, 1, data);
         }
     }
 
     public void fillRect(int x, int y, int width, int height, int rgb888) throws java.io.IOException {
+        PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
 
-        int[] rgb888pixels = new int[width * height];
+        byte[] data = new byte[(width * pixelFormat.getBitCount() + 7) / 8];
+        pixelFormat.fillRgb(data, 0, width, rgb888);
 
-        for (int row = 0; row < width; row++) {
-            for (int col = 0; col < height; col++) {
-
-                final int index = ((col * width) + row);
-                rgb888pixels[index] = rgb888;
-            }
+        for (int i = 0; i < height; i++) {
+            driver.setPixels(x, y + i, width, 1, data);
         }
-
-        drawImage(x, y, width, height, rgb888pixels);
-    }
-
-    protected byte[] pack12(int[] values) {
-        int n = values.length;
-        byte[] packed = new byte[(n * 12 + 7) / 8];
-
-        int out = 0;
-        for (int i = 0; i < n; i += 2) {
-            int v1 = values[i] & 0xFFF; // 12 bits
-            int v2 = (i + 1 < n) ? values[i + 1] & 0xFFF : 0;
-
-            // Layout (24 bits):
-            // byte0 = v1[11:4]
-            // byte1 = v1[3:0] << 4 | v2[11:8]
-            // byte2 = v2[7:0]
-
-            packed[out++] = (byte) (v1 >>> 4);
-            packed[out++] = (byte) ((v1 & 0xF) << 4 | (v2 >>> 8));
-            if (i + 1 < n) {
-                packed[out++] = (byte) (v2 & 0xFF);
-            }
-        }
-
-        return packed;
-    }
-
-    protected int rgb888toRgb565(int r, int g, int b) {
-
-        if (r < 0 || r > 255 || g < 0 || g > 255 || b < 0 || b > 255) {
-            throw new IllegalArgumentException("Invalid Colour (" + r + "," + g + "," + b + ")");
-        }
-
-        // rounding correction when reducing from 8 bits per channel to fewer bits, so that colors don’t just get
-        // truncated but instead rounded
-        // for red and blue: if the 3rd least significant bit is set (0x04), it adds 4.
-        // For green: if the 2nd least significant bit is set (0x02), it adds 2
-        if ((r & 0x04) != 0) {
-            r += 0x04;
-
-            if (r > 255) {
-                r = 255;
-            }
-        }
-
-        if ((g & 0x02) != 0) {
-            g += 0x02;
-
-            if (g > 255) {
-                g = 255;
-            }
-        }
-
-        if ((b & 0x04) != 0) {
-            b += 0x04;
-
-            if (b > 255) {
-                b = 255;
-            }
-        }
-
-        final int value = ((r >> 3) << 11) | ((g >> 2) << 5) | (b >> 3);
-        return value;
-
-    }
-
-    /*
-     * @param r red (0-255)
-     * @param g green (0-255)
-     * @param b blue (0-255)
-     * @return 12-bit packed RGB444 value
-     */
-    protected int rgb888toRgb444(int r, int g, int b) {
-
-        // Reduce 8-bit channel to 4-bit channel (0-255 -> 0-15)
-        int r4 = (r >> 4) & 0xF;
-        int g4 = (g >> 4) & 0xF;
-        int b4 = (b >> 4) & 0xF;
-
-        // Pack into 12 bits: RRRR GGGG BBBB
-        return (r4 << 8) | (g4 << 4) | b4;
     }
 }

--- a/src/main/java/com/pi4j/drivers/display/PixelFormat.java
+++ b/src/main/java/com/pi4j/drivers/display/PixelFormat.java
@@ -24,7 +24,7 @@ public enum PixelFormat {
     }
 
     // The total number of bits used by this format.
-    int getBitCount() {
+    public int getBitCount() {
         return redBitCount + greenBitCount + blueBitCount;
     }
 

--- a/src/main/java/com/pi4j/drivers/display/st7789/St7789Driver.java
+++ b/src/main/java/com/pi4j/drivers/display/st7789/St7789Driver.java
@@ -126,17 +126,21 @@ public class St7789Driver implements GraphicsDisplayDriver {
         dc.off();
     }
 
-    private void data(byte[] x) {
+    private void data(byte[] buf) {
+        data(buf, buf.length);
+    }
+
+    private void data(byte[] x, int length) {
         if (log.isTraceEnabled()) {  // Avoid large string allocation if logging is off.
             String raw = java.util.HexFormat.of().formatHex(x);
             if (raw.length() > 100) {
-                log.trace("Data: {} {}", x.length, raw.substring(0, 80));
+                log.trace("Data: {} {}", length, raw.substring(0, 80));
             } else {
-                log.trace("Data: {} {}", x.length, raw);
+                log.trace("Data: {} {}", length, raw);
             }
         }
         dc.on();
-        spi.write(x);
+        spi.write(x, length);
         dc.off();
     }
 
@@ -151,6 +155,6 @@ public class St7789Driver implements GraphicsDisplayDriver {
         command(CASET, x, x + width - 1); // Column addr set
         command(RASET, yOffset + y, yOffset + y + height - 1); // Row addr set
         command(RAMWR); // write to RAM
-        data(data);
+        data(data, width * height * displayInfo.getPixelFormat().getBitCount() / 8);
     }
 }

--- a/src/test/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponentTest.java
+++ b/src/test/java/com/pi4j/drivers/display/BaseGraphicsDisplayComponentTest.java
@@ -38,11 +38,10 @@ public class BaseGraphicsDisplayComponentTest {
         mockDisplay.fillRect(0, 0, 48, 1, Color.RED.getRGB());
 
         byte[] data = display.getData();
-        byte zeroZero = data[0];
 
         log.trace("Size of Data: {}", data.length);
         assertEquals((byte) 0xF8, data[0]);
-        assertEquals(48 * 16 / 8, data.length);
+        assertEquals(100 * 100 * 2, data.length);
     }
 
 }

--- a/src/test/java/com/pi4j/drivers/display/FakeDisplayDriver.java
+++ b/src/test/java/com/pi4j/drivers/display/FakeDisplayDriver.java
@@ -31,17 +31,29 @@ public class FakeDisplayDriver implements GraphicsDisplayDriver {
         log.trace("setPixels: {} {} {} {}", x, y, width, height);
         log.trace("\t" + HexFormat.of().formatHex(data));
 
+        if (x < 0 || x + width > displayInfo.getWidth()) {
+            throw new IllegalArgumentException("x " + x  + " + width " +width + " exceeds display width " + displayInfo.getWidth());
+        }
+        if (y <0 ||y + height > displayInfo.getHeight()) {
+            throw new IllegalArgumentException("y " + y  + " + height " +height + " exceeds display height " + displayInfo.getHeight());
+        }
+
         PixelFormat pixelFormat = displayInfo.getPixelFormat();
 
-        if (x * pixelFormat.getBitCount() % 8 != 0) {
-            throw new IllegalArgumentException("misaligned x address");
-        }
+        checkAlignment(x, "x-position");
+        checkAlignment(width, "width");
 
         for (int i = 0; i < height; i++) {
             System.arraycopy(
                     data, (i * width * pixelFormat.getBitCount() + 7) / 8,
                     this.data, ((i + y) * getDisplayInfo().getWidth() * pixelFormat.getBitCount() + x + 7) / 8,
                     (width * pixelFormat.getBitCount() + 7) / 8);
+        }
+    }
+
+    private void checkAlignment(int x, String target) {
+        if (x * displayInfo.getPixelFormat().getBitCount() % 8 != 0) {
+            throw new IllegalArgumentException("misaligned for " + target + " -- must be aligned on byte address");
         }
     }
 }

--- a/src/test/java/com/pi4j/drivers/display/FakeDisplayDriver.java
+++ b/src/test/java/com/pi4j/drivers/display/FakeDisplayDriver.java
@@ -14,6 +14,7 @@ public class FakeDisplayDriver implements GraphicsDisplayDriver {
 
     public FakeDisplayDriver(DisplayInfo displayInfo) {
         this.displayInfo = displayInfo;
+        this.data = new byte[(displayInfo.getWidth() * displayInfo.getHeight() * displayInfo.getPixelFormat().getBitCount() + 7) / 8];
     }
 
     public byte[] getData() {
@@ -22,7 +23,6 @@ public class FakeDisplayDriver implements GraphicsDisplayDriver {
 
     @Override
     public DisplayInfo getDisplayInfo() {
-
         return displayInfo;
     }
 
@@ -30,6 +30,18 @@ public class FakeDisplayDriver implements GraphicsDisplayDriver {
     public void setPixels(int x, int y, int width, int height, byte[] data) {
         log.trace("setPixels: {} {} {} {}", x, y, width, height);
         log.trace("\t" + HexFormat.of().formatHex(data));
-        this.data = data;
+
+        PixelFormat pixelFormat = displayInfo.getPixelFormat();
+
+        if (x * pixelFormat.getBitCount() % 8 != 0) {
+            throw new IllegalArgumentException("misaligned x address");
+        }
+
+        for (int i = 0; i < height; i++) {
+            System.arraycopy(
+                    data, (i * width * pixelFormat.getBitCount() + 7) / 8,
+                    this.data, ((i + y) * getDisplayInfo().getWidth() * pixelFormat.getBitCount() + x + 7) / 8,
+                    (width * pixelFormat.getBitCount() + 7) / 8);
+        }
     }
 }

--- a/src/test/java/com/pi4j/drivers/display/st7789/St7789DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/st7789/St7789DriverTest.java
@@ -70,7 +70,8 @@ public class St7789DriverTest {
             DigitalOutput dc = pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j).address(DC_ADDRESS).build());
             Spi spi = pi4j.create(SpiConfigBuilder.newInstance(pi4j).bus(SPI_BUS).address(SPI_ADDRESS).baud(SPI_BAUDRATE).build());
             return new St7789Driver(spi, dc, 240, PixelFormat.RGB_444);
-        } catch (Pi4JException e) {
+        } catch (RuntimeException e) {
+            // TODO(https://github.com/Pi4J/pi4j/issues/489): Catch Pi4j exceptions instead.
             Assumptions.abort("St7789 not found");
             throw new RuntimeException(e);
         }

--- a/src/test/java/com/pi4j/drivers/display/st7789/St7789DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/st7789/St7789DriverTest.java
@@ -1,0 +1,78 @@
+package com.pi4j.drivers.display.st7789;
+
+import com.pi4j.Pi4J;
+import com.pi4j.context.Context;
+import com.pi4j.drivers.display.BaseGraphicsDisplayComponent;
+import com.pi4j.drivers.display.DisplayInfo;
+import com.pi4j.drivers.display.PixelFormat;
+import com.pi4j.exception.Pi4JException;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder;
+import com.pi4j.io.spi.Spi;
+import com.pi4j.io.spi.SpiConfigBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Random;
+
+/**
+ * This test assumes the waveshare 1.3inch IPS display HAT pinout, see
+ * https://www.waveshare.com/1.3inch-lcd-hat.htm
+ */
+public class St7789DriverTest {
+    private static final int BACKLIGHT_ADDRESS = 24;
+    private static final int DC_ADDRESS = 25;
+    private static final int RST_ADDRESS = 27;
+    private static final int SPI_BUS = 0;
+    private static final int SPI_ADDRESS = 0;
+
+    private Context pi4j;
+
+    @BeforeEach
+    public void setUp() {
+        pi4j = Pi4J.newAutoContext();
+    }
+
+    @AfterEach
+    public void tearDown() {
+        pi4j.shutdown();
+    }
+
+    @Test
+    public void testFillRect() {
+        St7789Driver driver = createDriver();
+        BaseGraphicsDisplayComponent display = new BaseGraphicsDisplayComponent(driver);
+        DisplayInfo displayInfo = driver.getDisplayInfo();
+        int width = displayInfo.getWidth();
+        int height = displayInfo.getHeight();
+        display.fillRect(0, 0, width, height, 0xffffff);
+        Random random = new Random(0);
+        for (int i = 0; i < 10; i++) {
+            int x = random.nextInt(width);
+            int y = random.nextInt(height);
+            int w = random.nextInt(width - x);
+            int h = random.nextInt(height - y);
+            int color = random.nextInt(0xffffff);
+            display.fillRect(x, y, w, h, color);
+        }
+    }
+
+
+    private St7789Driver createDriver()  {
+        try {
+            DigitalOutput bl = pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j).address(BACKLIGHT_ADDRESS).build());
+            bl.high();
+            DigitalOutput rst = pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j).address(RST_ADDRESS).build());
+            rst.high();
+            DigitalOutput dc = pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j).address(DC_ADDRESS).build());
+            Spi spi = pi4j.create(SpiConfigBuilder.newInstance(pi4j).bus(SPI_BUS).address(SPI_ADDRESS).build());
+            return new St7789Driver(spi, dc, 240, PixelFormat.RGB_565);
+        } catch (Pi4JException e) {
+            Assumptions.abort("St7789 not found");
+            throw new RuntimeException(e);
+        }
+    }
+
+}

--- a/src/test/java/com/pi4j/drivers/display/st7789/St7789DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/st7789/St7789DriverTest.java
@@ -68,7 +68,7 @@ public class St7789DriverTest {
             rst.high();
             DigitalOutput dc = pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j).address(DC_ADDRESS).build());
             Spi spi = pi4j.create(SpiConfigBuilder.newInstance(pi4j).bus(SPI_BUS).address(SPI_ADDRESS).build());
-            return new St7789Driver(spi, dc, 240, PixelFormat.RGB_565);
+            return new St7789Driver(spi, dc, 240, PixelFormat.RGB_444);
         } catch (Pi4JException e) {
             Assumptions.abort("St7789 not found");
             throw new RuntimeException(e);

--- a/src/test/java/com/pi4j/drivers/display/st7789/St7789DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/st7789/St7789DriverTest.java
@@ -24,6 +24,7 @@ import java.util.Random;
 public class St7789DriverTest {
     private static final int BACKLIGHT_ADDRESS = 24;
     private static final int DC_ADDRESS = 25;
+    private static final int SPI_BAUDRATE = 62_500_000;
     private static final int RST_ADDRESS = 27;
     private static final int SPI_BUS = 0;
     private static final int SPI_ADDRESS = 0;
@@ -67,7 +68,7 @@ public class St7789DriverTest {
             DigitalOutput rst = pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j).address(RST_ADDRESS).build());
             rst.high();
             DigitalOutput dc = pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j).address(DC_ADDRESS).build());
-            Spi spi = pi4j.create(SpiConfigBuilder.newInstance(pi4j).bus(SPI_BUS).address(SPI_ADDRESS).build());
+            Spi spi = pi4j.create(SpiConfigBuilder.newInstance(pi4j).bus(SPI_BUS).address(SPI_ADDRESS).baud(SPI_BAUDRATE).build());
             return new St7789Driver(spi, dc, 240, PixelFormat.RGB_444);
         } catch (Pi4JException e) {
             Assumptions.abort("St7789 not found");


### PR DESCRIPTION
- Break transfers into rows to avoid large transfers that potentially exceed the default SPI maximum (also reducing memory overhead)
- Change the FakeDisplayDriver to emulate a full display with updateable sections (at pixel aligned byte boundaries)
- Adjust the tests accordingly