### PR TITLE
Add buffering to BaseDisplayComponent, as described in an earlier drivers channel slack post.

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/graphics/BaseDisplayComponent.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/BaseDisplayComponent.java
@@ -3,18 +3,32 @@ package com.pi4j.drivers.display.graphics;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.Arrays;
+import java.util.Timer;
+import java.util.TimerTask;
+
 public class BaseDisplayComponent {
     // TODO(https://github.com/Pi4J/pi4j/issues/475): Remove or update this limitation.
     private static final int MAX_TRANSFER_SIZE = 4000;
 
-    private static Logger log = LoggerFactory.getLogger(BaseDisplayComponent.class);
-
     protected final DisplayDriver driver;
+    private final Object lock = new Object();
+    private final int[] displayBuffer;
     private final byte[] transferBuffer;
+    private final Timer timer = new Timer();
+
+    private int modifiedXMax = Integer.MIN_VALUE;
+    private int modifiedXMin = Integer.MAX_VALUE;
+    private int modifiedYMax = Integer.MIN_VALUE;
+    private int modifiedYMin = Integer.MAX_VALUE;
+    private boolean updatePending = false;
+    private int transferDelayMillis = 20;
 
     public BaseDisplayComponent(DisplayDriver driver) {
         this.driver = driver;
-        transferBuffer = new byte[Math.min(MAX_TRANSFER_SIZE,
+        displayBuffer = new int[driver.getDisplayInfo().getWidth() * driver.getDisplayInfo().getHeight()];
+        transferBuffer = new byte[Math.min(
+                MAX_TRANSFER_SIZE,
                 (driver.getDisplayInfo().getHeight() * driver.getDisplayInfo().getWidth()
                         * driver.getDisplayInfo().getPixelFormat().getBitCount() + 7) / 8)];
     }
@@ -22,35 +36,101 @@ public class BaseDisplayComponent {
     // it is possible that rgb888pixels contains more than will fit
     // we will just ignore them
     public void drawImage(int x, int y, int width, int height, int[] rgb888pixels) {
-        log.debug("drawImage: {},{} \t {} x {} \t {}", x, y, width, height, rgb888pixels.length);
-        PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
+        synchronized (lock) {
+            for (int i = 0; i < height; i++) {
+                System.arraycopy(
+                        rgb888pixels,
+                        i * width,
+                        displayBuffer,
+                        pixelAddress(x, y + i),
+                        width);
+            }
+            markDirty(x, y, width, height);
+        }
+    }
 
-        int bitsPerRow = width * pixelFormat.getBitCount();
-        int bitOffset = 0;
-        for (int i = 0; i < height; i++) {
-            bitOffset += pixelFormat.writeRgb(rgb888pixels, width * i, transferBuffer, bitOffset, width);
-            // Transfer if the last row is reached or the next row would overflow the buffer.
-            if (i == height - 1 || bitOffset + bitsPerRow > transferBuffer.length * 8) {
-                int rows = bitOffset / bitsPerRow;
-                driver.setPixels(x, y + i + 1 - rows, width, rows, transferBuffer);
-                bitOffset = 0;
+    public void setPixel(int x, int y, int color) {
+        synchronized (lock) {
+            displayBuffer[pixelAddress(x, y)] = color;
+            markDirty(x, y, 1, 1);
+        }
+    }
+
+
+    private void markDirty(int x, int y, int width, int height) {
+        synchronized (lock) {
+            if (transferDelayMillis == 0) {
+                transferBuffer(x, y, width, height);
+            } else {
+                if (x < modifiedXMin) {
+                    modifiedXMin = x;
+                }
+                if (x + width > modifiedXMax) {
+                    modifiedXMax = x + width;
+                }
+                if (y < modifiedYMin) {
+                    modifiedYMin = y;
+                }
+                if (y + height > modifiedYMax) {
+                    modifiedYMax = y + height;
+                }
+                if (!updatePending) {
+                    updatePending = true;
+                    timer.schedule(new TimerTask() {
+                        @Override
+                        public void run() {
+                            synchronized (lock) {
+                                updatePending = false;
+                                transferBuffer(
+                                        modifiedXMin,
+                                        modifiedYMin,
+                                        modifiedXMax - modifiedXMin,
+                                        modifiedYMax - modifiedYMin);
+                            }
+                        }
+                    }, transferDelayMillis);
+                }
+            }
+        }
+    }
+
+    /** Returns the address of the given pixel in the display buffer */
+    private int pixelAddress(int x, int y) {
+        return y * driver.getDisplayInfo().getWidth() + x;
+    }
+
+    private void transferBuffer(int x, int y, int width, int height) {
+        synchronized (lock) {
+            PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
+            int bitsPerRow = width * pixelFormat.getBitCount();
+            int bitOffset = 0;
+            for (int i = 0; i < height; i++) {
+                bitOffset += pixelFormat.writeRgb(
+                        displayBuffer,
+                        pixelAddress(x, y + i),
+                        transferBuffer,
+                        bitOffset,
+                        width);
+                // Transfer if the last row is reached or the next row would overflow the buffer.
+                if (i == height - 1 || bitOffset + bitsPerRow > transferBuffer.length * 8) {
+                    int rows = bitOffset / bitsPerRow;
+                    driver.setPixels(x, y + i + 1 - rows, width, rows, transferBuffer);
+                    bitOffset = 0;
+                }
             }
         }
     }
 
     public void fillRect(int x, int y, int width, int height, int rgb888) {
-        if (width <= 0 || height <= 0) {
-            return;
-        }
-        PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
-
-        int bitsPerRow = width * pixelFormat.getBitCount();
-        int rowCount = transferBuffer.length * 8 / bitsPerRow;
-
-        pixelFormat.fillRgb(transferBuffer, 0, width * rowCount, rgb888);
-
-        for (int i = 0; i < height; i += rowCount) {
-            driver.setPixels(x, y + i, width, Math.min(rowCount, height - i), transferBuffer);
+        synchronized (lock) {
+            if (width <= 0 || height <= 0) {
+                return;
+            }
+            for (int i = 0; i < height; i++) {
+                int start = pixelAddress(x, y + i);
+                Arrays.fill(displayBuffer, rgb888, start, start + width);
+            }
+            markDirty(x, y, width, height);
         }
     }
 }

--- a/src/test/java/com/pi4j/drivers/display/graphics/AbstractDisplayDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/AbstractDisplayDriverTest.java
@@ -43,6 +43,7 @@ public abstract class AbstractDisplayDriverTest {
             Thread.sleep(100);
         }
         display.fillRect(0, 0, width, height, 0);
+        display.flush(); // Make sure we don't get writes later.
     }
 
 }

--- a/src/test/java/com/pi4j/drivers/display/graphics/AwtDisplayComponentTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/AwtDisplayComponentTest.java
@@ -33,6 +33,7 @@ public class AwtDisplayComponentTest {
 
         FakeDisplayDriver display = new FakeDisplayDriver(new DisplayInfo(10, 10, PixelFormat.RGB_444));
         AwtDisplayComponent mockDisplay = new AwtDisplayComponent(display);
+        mockDisplay.setTransferDelayMillis(0);
 
         BufferedImage img = new BufferedImage(12, 12, BufferedImage.TYPE_4BYTE_ABGR);
         Graphics2D g2d = img.createGraphics();
@@ -55,6 +56,7 @@ public class AwtDisplayComponentTest {
 
         FakeDisplayDriver display = new FakeDisplayDriver(new DisplayInfo(10, 10, PixelFormat.RGB_565));
         AwtDisplayComponent mockDisplay = new AwtDisplayComponent(display);
+        mockDisplay.setTransferDelayMillis(0);
 
         BufferedImage img = new BufferedImage(12, 12, BufferedImage.TYPE_4BYTE_ABGR);
         Graphics2D g2d = img.createGraphics();
@@ -76,6 +78,7 @@ public class AwtDisplayComponentTest {
 
         FakeDisplayDriver display = new FakeDisplayDriver(new DisplayInfo(10, 10, PixelFormat.RGB_444));
         AwtDisplayComponent mockDisplay = new AwtDisplayComponent(display);
+        mockDisplay.setTransferDelayMillis(0);
 
         BufferedImage img = makeDataBufferInt();
         mockDisplay.display(img);
@@ -92,6 +95,7 @@ public class AwtDisplayComponentTest {
 
         FakeDisplayDriver display = new FakeDisplayDriver(new DisplayInfo(10, 10, PixelFormat.RGB_565));
         AwtDisplayComponent mockDisplay = new AwtDisplayComponent(display);
+        mockDisplay.setTransferDelayMillis(0);
 
         BufferedImage img = makeDataBufferInt();
         mockDisplay.display(img);

--- a/src/test/java/com/pi4j/drivers/display/graphics/BaseDisplayComponentTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/BaseDisplayComponentTest.java
@@ -35,6 +35,7 @@ public class BaseDisplayComponentTest {
 
         FakeDisplayDriver display = new FakeDisplayDriver(new DisplayInfo(100, 100, PixelFormat.RGB_565));
         BaseDisplayComponent mockDisplay = new BaseDisplayComponent(display);
+        mockDisplay.setTransferDelayMillis(0);
         mockDisplay.fillRect(0, 0, 48, 1, Color.RED.getRGB());
 
         byte[] data = display.getData();

--- a/src/test/java/com/pi4j/drivers/display/graphics/st7789/St7789DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/st7789/St7789DriverTest.java
@@ -1,7 +1,9 @@
 package com.pi4j.drivers.display.graphics.st7789;
 
 import com.pi4j.context.Context;
-import com.pi4j.drivers.display.graphics.*;
+import com.pi4j.drivers.display.graphics.AbstractDisplayDriverTest;
+import com.pi4j.drivers.display.graphics.DisplayDriver;
+import com.pi4j.drivers.display.graphics.PixelFormat;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder;
 import com.pi4j.io.spi.Spi;


### PR DESCRIPTION
This simplifies handling displays that may require updates for pixels outside the area immediately affected by drawing operations. For instance, WS2812 based LED strips always require data for all pixels up to the last modified pixel.

This also reduces the amount of data sent if there are overlapping drawing operations.

