### PR TITLE
Rename graphics drivers as discussed earlier on slack

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/graphics/AwtGraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/AwtGraphicsDisplay.java
@@ -5,18 +5,18 @@ import java.awt.image.BufferedImage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-public class AwtDisplayComponent extends BaseDisplayComponent {
+public class AwtGraphicsDisplay extends GraphicsDisplay {
 
-    private static Logger log = LoggerFactory.getLogger(AwtDisplayComponent.class);
+    private static Logger log = LoggerFactory.getLogger(AwtGraphicsDisplay.class);
 
-    public AwtDisplayComponent(DisplayDriver driver) {
+    public AwtGraphicsDisplay(GraphicsDisplayDriver driver) {
         super(driver);
     }
 
     public void display(BufferedImage rawImg) {
 
         log.debug("display: {} {} x {}", rawImg.getType(), rawImg.getWidth(), rawImg.getHeight());
-        DisplayInfo displayInfo = driver.getDisplayInfo();
+        GraphicsDisplayInfo displayInfo = driver.getDisplayInfo();
 
         // clip the image to what will fit on the display
         BufferedImage img = rawImg.getSubimage(0, 0, Math.min(rawImg.getWidth(), displayInfo.getWidth()),

--- a/src/main/java/com/pi4j/drivers/display/graphics/BitmapFont.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/BitmapFont.java
@@ -120,7 +120,7 @@ public class BitmapFont {
      * <p>
      * Returns the width of the rendered text in pixel.
      */
-    public int renderText(BaseDisplayComponent display, int x, int baselineY, String text, int color) {
+    public int renderText(GraphicsDisplay display, int x, int baselineY, String text, int color) {
         return renderText(display, x, baselineY, text, color, EnumSet.noneOf(Option.class), 1, 1);
     }
 
@@ -130,7 +130,7 @@ public class BitmapFont {
      * Returns the width of the rendered text in pixel.
      */
     public int renderText(
-            BaseDisplayComponent display,
+            GraphicsDisplay display,
             int x,
             int baselineY,
             String text,
@@ -155,7 +155,7 @@ public class BitmapFont {
      * Returns the width of the character in pixel.
      */
     public int renderCharacter(
-            BaseDisplayComponent display,
+            GraphicsDisplay display,
             int x0,
             int baselineY,
             int codepoint,

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -4,11 +4,11 @@ import java.util.Arrays;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class BaseDisplayComponent {
+public class GraphicsDisplay {
     // TODO(https://github.com/Pi4J/pi4j/issues/475): Remove or update this limitation.
     private static final int MAX_TRANSFER_SIZE = 4000;
 
-    protected final DisplayDriver driver;
+    protected final GraphicsDisplayDriver driver;
     private final Object lock = new Object();
     private final int[] displayBuffer;
     private final byte[] transferBuffer;
@@ -23,7 +23,7 @@ public class BaseDisplayComponent {
     private final int displayWidth;
     private final int displayHeight;
 
-    public BaseDisplayComponent(DisplayDriver driver) {
+    public GraphicsDisplay(GraphicsDisplayDriver driver) {
         this.driver = driver;
         displayWidth = driver.getDisplayInfo().getWidth();
         displayHeight = driver.getDisplayInfo().getHeight();

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplayDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplayDriver.java
@@ -1,8 +1,8 @@
 package com.pi4j.drivers.display.graphics;
 
-public interface DisplayDriver {
+public interface GraphicsDisplayDriver {
 
-    DisplayInfo getDisplayInfo();
+    GraphicsDisplayInfo getDisplayInfo();
 
     void setPixels(int x, int y, int width, int height, byte[] data);
 }

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplayInfo.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplayInfo.java
@@ -1,12 +1,12 @@
 package com.pi4j.drivers.display.graphics;
 
-public class DisplayInfo {
+public class GraphicsDisplayInfo {
 
     private final int width;
     private final int height;
     private final PixelFormat pixelFormat;
 
-    public DisplayInfo(int width, int height, PixelFormat pixelFormat) {
+    public GraphicsDisplayInfo(int width, int height, PixelFormat pixelFormat) {
         this.width = width;
         this.height = height;
         this.pixelFormat = pixelFormat;

--- a/src/main/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriver.java
@@ -1,8 +1,8 @@
 package com.pi4j.drivers.display.graphics.crowpi2matrix;
 
 import com.pi4j.context.Context;
-import com.pi4j.drivers.display.graphics.DisplayDriver;
-import com.pi4j.drivers.display.graphics.DisplayInfo;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayInfo;
 import com.pi4j.drivers.display.graphics.PixelFormat;
 import com.pi4j.io.i2c.I2C;
 
@@ -13,10 +13,10 @@ import java.util.Arrays;
 /**
  * Driver for the new I2C based CrowPi2 LED matrix that is used in the Pi5-compatible model.
  */
-public class CrowPi2I2cLedMatrixDriver implements DisplayDriver {
+public class CrowPi2I2cLedMatrixDriver implements GraphicsDisplayDriver {
     public static final int I2C_ADDRESS = 0x66;
 
-    private final DisplayInfo displayInfo = new DisplayInfo(8, 8, PixelFormat.RGB_888);
+    private final GraphicsDisplayInfo displayInfo = new GraphicsDisplayInfo(8, 8, PixelFormat.RGB_888);
     private final I2C i2c;
     byte[] writeBuf = new byte[Offset.values().length];
 
@@ -35,7 +35,7 @@ public class CrowPi2I2cLedMatrixDriver implements DisplayDriver {
     }
 
     @Override
-    public DisplayInfo getDisplayInfo() {
+    public GraphicsDisplayInfo getDisplayInfo() {
         return displayInfo;
     }
 

--- a/src/main/java/com/pi4j/drivers/display/graphics/st7789/St7789Driver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/st7789/St7789Driver.java
@@ -1,8 +1,8 @@
 package com.pi4j.drivers.display.graphics.st7789;
 
-import com.pi4j.drivers.display.graphics.DisplayDriver;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
 import com.pi4j.drivers.display.graphics.PixelFormat;
-import com.pi4j.drivers.display.graphics.DisplayInfo;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayInfo;
 
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.spi.Spi;
@@ -15,7 +15,7 @@ import org.slf4j.LoggerFactory;
  * https://www.adafruit.com/product/3787
  */
 
-public class St7789Driver implements DisplayDriver {
+public class St7789Driver implements GraphicsDisplayDriver {
 
     private static Logger log = LoggerFactory.getLogger(St7789Driver.class);
     private final static int WIDTH = 240;
@@ -46,12 +46,12 @@ public class St7789Driver implements DisplayDriver {
 
     private final Spi spi;
     private final DigitalOutput dc;
-    private final DisplayInfo displayInfo;
+    private final GraphicsDisplayInfo displayInfo;
 
     public St7789Driver(Spi spi, DigitalOutput dc, int displayHeight, PixelFormat pixelFormat) {
         this.spi = spi;
         this.dc = dc;
-        this.displayInfo = new DisplayInfo(WIDTH, displayHeight, pixelFormat);
+        this.displayInfo = new GraphicsDisplayInfo(WIDTH, displayHeight, pixelFormat);
         this.yOffset = 320 - displayHeight;
 
         init();
@@ -145,7 +145,7 @@ public class St7789Driver implements DisplayDriver {
     }
 
     @Override
-    public DisplayInfo getDisplayInfo() {
+    public GraphicsDisplayInfo getDisplayInfo() {
         return displayInfo;
     }
 

--- a/src/main/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriver.java
@@ -1,7 +1,7 @@
 package com.pi4j.drivers.display.graphics.ws281x;
 
-import com.pi4j.drivers.display.graphics.DisplayDriver;
-import com.pi4j.drivers.display.graphics.DisplayInfo;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayInfo;
 import com.pi4j.drivers.display.graphics.PixelFormat;
 import com.pi4j.io.spi.Spi;
 
@@ -12,7 +12,7 @@ import com.pi4j.io.spi.Spi;
  * This driver is based on timing information form this article:
  * https://wp.josh.com/2014/05/13/ws2812-neopixels-are-not-so-finicky-once-you-get-to-know-them/
  */
-public class Ws281xDriver implements DisplayDriver {
+public class Ws281xDriver implements GraphicsDisplayDriver {
     /** The number of color channels (r, g, b); each using one byte. */
     private static final int COLOR_CHANNELS = 3;
     /**
@@ -27,7 +27,7 @@ public class Ws281xDriver implements DisplayDriver {
 
     /** A buffer of the transformed pixels in the format they will be sent over SPI */
     private final byte[] spiBuffer;
-    private final DisplayInfo displayInfo;
+    private final GraphicsDisplayInfo displayInfo;
     private final Spi spi;
 
     /**
@@ -39,11 +39,11 @@ public class Ws281xDriver implements DisplayDriver {
     public Ws281xDriver(Spi spi, int width, int height) {
         this.spi = spi;
         spiBuffer = new byte[width * height * COLOR_CHANNELS * BIT_STRETCH];
-        displayInfo = new DisplayInfo(width, height, PixelFormat.RGB_888);
+        displayInfo = new GraphicsDisplayInfo(width, height, PixelFormat.RGB_888);
     }
 
     @Override
-    public DisplayInfo getDisplayInfo() {
+    public GraphicsDisplayInfo getDisplayInfo() {
         return displayInfo;
     }
 

--- a/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
@@ -11,7 +11,7 @@ import org.junit.jupiter.api.Test;
 import java.util.EnumSet;
 import java.util.Random;
 
-public abstract class AbstractDisplayDriverTest {
+public abstract class AbstractGraphicsDisplayDriverTest {
     private Context pi4j;
 
     @BeforeEach
@@ -24,13 +24,13 @@ public abstract class AbstractDisplayDriverTest {
         pi4j.shutdown();
     }
 
-    public abstract DisplayDriver createDriver(Context pi4j);
+    public abstract GraphicsDisplayDriver createDriver(Context pi4j);
 
     @Test
     public void testFillRect() throws InterruptedException {
-        DisplayDriver driver = createDriver(pi4j);
-        BaseDisplayComponent display = new BaseDisplayComponent(driver);
-        DisplayInfo displayInfo = driver.getDisplayInfo();
+        GraphicsDisplayDriver driver = createDriver(pi4j);
+        GraphicsDisplay display = new GraphicsDisplay(driver);
+        GraphicsDisplayInfo displayInfo = driver.getDisplayInfo();
         int width = displayInfo.getWidth();
         int height = displayInfo.getHeight();
         display.fillRect(0, 0, width, height, 0x0);
@@ -49,9 +49,9 @@ public abstract class AbstractDisplayDriverTest {
 
     @Test
     public void testBitmapFont() throws InterruptedException {
-        DisplayDriver driver = createDriver(pi4j);
-        BaseDisplayComponent display = new BaseDisplayComponent(driver);
-        DisplayInfo displayInfo = driver.getDisplayInfo();
+        GraphicsDisplayDriver driver = createDriver(pi4j);
+        GraphicsDisplay display = new GraphicsDisplay(driver);
+        GraphicsDisplayInfo displayInfo = driver.getDisplayInfo();
         int width = displayInfo.getWidth();
         int height = displayInfo.getHeight();
         display.fillRect(0, 0, width, height, 0);

--- a/src/test/java/com/pi4j/drivers/display/graphics/AwtGraphicsDisplayTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/AwtGraphicsDisplayTest.java
@@ -1,6 +1,5 @@
 package com.pi4j.drivers.display.graphics;
 
-import java.awt.Color;
 import java.awt.Graphics2D;
 import java.awt.image.BufferedImage;
 import java.awt.image.ColorModel;
@@ -20,19 +19,16 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.pi4j.drivers.display.graphics.DisplayInfo;
-import com.pi4j.drivers.display.graphics.PixelFormat;
+public class AwtGraphicsDisplayTest {
 
-public class AwtDisplayComponentTest {
-
-    private static Logger log = LoggerFactory.getLogger(AwtDisplayComponentTest.class);
+    private static Logger log = LoggerFactory.getLogger(AwtGraphicsDisplayTest.class);
 
     // 12 bit test
     @Test
     public void testRgb888toRgb444() throws IOException {
 
-        FakeDisplayDriver display = new FakeDisplayDriver(new DisplayInfo(10, 10, PixelFormat.RGB_444));
-        AwtDisplayComponent mockDisplay = new AwtDisplayComponent(display);
+        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(10, 10, PixelFormat.RGB_444));
+        AwtGraphicsDisplay mockDisplay = new AwtGraphicsDisplay(display);
         mockDisplay.setTransferDelayMillis(0);
 
         BufferedImage img = new BufferedImage(12, 12, BufferedImage.TYPE_4BYTE_ABGR);
@@ -54,8 +50,8 @@ public class AwtDisplayComponentTest {
     @Test
     public void testRgb888toRgb565() throws IOException {
 
-        FakeDisplayDriver display = new FakeDisplayDriver(new DisplayInfo(10, 10, PixelFormat.RGB_565));
-        AwtDisplayComponent mockDisplay = new AwtDisplayComponent(display);
+        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(10, 10, PixelFormat.RGB_565));
+        AwtGraphicsDisplay mockDisplay = new AwtGraphicsDisplay(display);
         mockDisplay.setTransferDelayMillis(0);
 
         BufferedImage img = new BufferedImage(12, 12, BufferedImage.TYPE_4BYTE_ABGR);
@@ -76,8 +72,8 @@ public class AwtDisplayComponentTest {
     @Test
     public void testDisplayDataBufferInt444() {
 
-        FakeDisplayDriver display = new FakeDisplayDriver(new DisplayInfo(10, 10, PixelFormat.RGB_444));
-        AwtDisplayComponent mockDisplay = new AwtDisplayComponent(display);
+        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(10, 10, PixelFormat.RGB_444));
+        AwtGraphicsDisplay mockDisplay = new AwtGraphicsDisplay(display);
         mockDisplay.setTransferDelayMillis(0);
 
         BufferedImage img = makeDataBufferInt();
@@ -93,8 +89,8 @@ public class AwtDisplayComponentTest {
     @Test
     public void testDisplayDataBufferInt565() {
 
-        FakeDisplayDriver display = new FakeDisplayDriver(new DisplayInfo(10, 10, PixelFormat.RGB_565));
-        AwtDisplayComponent mockDisplay = new AwtDisplayComponent(display);
+        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(10, 10, PixelFormat.RGB_565));
+        AwtGraphicsDisplay mockDisplay = new AwtGraphicsDisplay(display);
         mockDisplay.setTransferDelayMillis(0);
 
         BufferedImage img = makeDataBufferInt();

--- a/src/test/java/com/pi4j/drivers/display/graphics/FakeGraphicsDisplayDriver.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/FakeGraphicsDisplayDriver.java
@@ -1,11 +1,11 @@
 package com.pi4j.drivers.display.graphics;
 
-public class FakeDisplayDriver implements DisplayDriver {
+public class FakeGraphicsDisplayDriver implements GraphicsDisplayDriver {
 
     private byte[] data;
-    private DisplayInfo displayInfo;
+    private GraphicsDisplayInfo displayInfo;
 
-    public FakeDisplayDriver(DisplayInfo displayInfo) {
+    public FakeGraphicsDisplayDriver(GraphicsDisplayInfo displayInfo) {
         this.displayInfo = displayInfo;
         this.data = new byte[(displayInfo.getWidth() * displayInfo.getHeight()
                 * displayInfo.getPixelFormat().getBitCount() + 7) / 8];
@@ -16,7 +16,7 @@ public class FakeDisplayDriver implements DisplayDriver {
     }
 
     @Override
-    public DisplayInfo getDisplayInfo() {
+    public GraphicsDisplayInfo getDisplayInfo() {
         return displayInfo;
     }
 

--- a/src/test/java/com/pi4j/drivers/display/graphics/GraphicsDisplayTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/GraphicsDisplayTest.java
@@ -2,18 +2,17 @@ package com.pi4j.drivers.display.graphics;
 
 import java.awt.Color;
 import java.io.IOException;
-import java.util.Arrays;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
-public class BaseDisplayComponentTest {
+public class GraphicsDisplayTest {
 
     // 12 bit test
     @Test
     public void testRgb888toRgb444() throws IOException {
-        FakeDisplayDriver driver = new FakeDisplayDriver(new DisplayInfo(100, 100, PixelFormat.RGB_444));
-        BaseDisplayComponent display = new BaseDisplayComponent(driver);
+        FakeGraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(100, 100, PixelFormat.RGB_444));
+        GraphicsDisplay display = new GraphicsDisplay(driver);
         display.fillRect(0, 0, 48, 1, Color.RED.getRGB());
         display.flush();
 
@@ -26,8 +25,8 @@ public class BaseDisplayComponentTest {
     // 16 bit test
     @Test
     public void testRgb888toRgb565() throws IOException {
-        FakeDisplayDriver driver = new FakeDisplayDriver(new DisplayInfo(100, 100, PixelFormat.RGB_565));
-        BaseDisplayComponent display = new BaseDisplayComponent(driver);
+        FakeGraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(100, 100, PixelFormat.RGB_565));
+        GraphicsDisplay display = new GraphicsDisplay(driver);
         display.setTransferDelayMillis(0);
         display.fillRect(0, 0, 48, 1, Color.RED.getRGB());
 
@@ -39,8 +38,8 @@ public class BaseDisplayComponentTest {
 
     @Test
     public void testSetPixel() {
-        FakeDisplayDriver driver = new FakeDisplayDriver(new DisplayInfo(100, 100, PixelFormat.RGB_888));
-        BaseDisplayComponent display = new BaseDisplayComponent(driver);
+        FakeGraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(100, 100, PixelFormat.RGB_888));
+        GraphicsDisplay display = new GraphicsDisplay(driver);
         display.setTransferDelayMillis(0);
         display.setPixel(10, 10, 0x112233);
 
@@ -48,7 +47,6 @@ public class BaseDisplayComponentTest {
         assertEquals(100 * 100 * 3, data.length);
 
         int pos = (10 * 100 + 10) * 3;
-        System.out.println(Arrays.toString(data));
         assertEquals(0x11, data[pos]);
         assertEquals(0x22, data[pos+1]);
         assertEquals(0x33, data[pos+2]);

--- a/src/test/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriverTest.java
@@ -1,13 +1,13 @@
 package com.pi4j.drivers.display.graphics.crowpi2matrix;
 
 import com.pi4j.context.Context;
-import com.pi4j.drivers.display.graphics.AbstractDisplayDriverTest;
-import com.pi4j.drivers.display.graphics.DisplayDriver;
+import com.pi4j.drivers.display.graphics.AbstractGraphicsDisplayDriverTest;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
 import org.junit.jupiter.api.Assumptions;
 
-public class CrowPi2I2cLedMatrixDriverTest extends AbstractDisplayDriverTest {
+public class CrowPi2I2cLedMatrixDriverTest extends AbstractGraphicsDisplayDriverTest {
     @Override
-    public DisplayDriver createDriver(Context pi4j) {
+    public GraphicsDisplayDriver createDriver(Context pi4j) {
         try {
             return new CrowPi2I2cLedMatrixDriver(pi4j);
         } catch (RuntimeException e) {

--- a/src/test/java/com/pi4j/drivers/display/graphics/st7789/St7789DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/st7789/St7789DriverTest.java
@@ -1,8 +1,8 @@
 package com.pi4j.drivers.display.graphics.st7789;
 
 import com.pi4j.context.Context;
-import com.pi4j.drivers.display.graphics.AbstractDisplayDriverTest;
-import com.pi4j.drivers.display.graphics.DisplayDriver;
+import com.pi4j.drivers.display.graphics.AbstractGraphicsDisplayDriverTest;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
 import com.pi4j.drivers.display.graphics.PixelFormat;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder;
@@ -13,7 +13,7 @@ import org.junit.jupiter.api.Assumptions;
 /**
  * This test assumes the waveshare 1.3inch IPS display HAT pinout, see https://www.waveshare.com/1.3inch-lcd-hat.htm
  */
-public class St7789DriverTest extends AbstractDisplayDriverTest {
+public class St7789DriverTest extends AbstractGraphicsDisplayDriverTest {
     private static final int BACKLIGHT_ADDRESS = 24;
     private static final int DC_ADDRESS = 25;
     private static final int SPI_BAUDRATE = 62_500_000;
@@ -22,7 +22,7 @@ public class St7789DriverTest extends AbstractDisplayDriverTest {
     private static final int SPI_ADDRESS = 0;
 
     @Override
-    public DisplayDriver createDriver(Context pi4j) {
+    public GraphicsDisplayDriver createDriver(Context pi4j) {
         try {
             DigitalOutput bl = pi4j
                     .create(DigitalOutputConfigBuilder.newInstance(pi4j).address(BACKLIGHT_ADDRESS).build());

--- a/src/test/java/com/pi4j/drivers/display/text/hd44780/Hd44780DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/text/hd44780/Hd44780DriverTest.java
@@ -46,11 +46,12 @@ public class Hd44780DriverTest {
         try {
             I2C i2c = pi4j.create(I2C.newConfigBuilder(pi4j)
                     .bus(BUS)
-                    .device(DEVICE_ADDRESS)
+                    .device(0x21) //DEVICE_ADDRESS)
                     .build());
 
-            return Hd44780Driver.withPcf8574Connection(i2c, 20, 4);
+            return Hd44780Driver.withMcp23008Connection(i2c, 16, 2);
         } catch (RuntimeException e) {
+            e.printStackTrace();
             // TODO(https://github.com/Pi4J/pi4j/issues/489): Catch Pi4j exceptions instead.
             Assumptions.abort("HD 44780 connected via PCF 8574 not found");
             throw new RuntimeException(e);


### PR DESCRIPTION
Should be a pure rename apart from removing a spurious println