### PR TITLE
Graphics driver x-coordinate granularity and pixel transfer stride support

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -121,8 +121,13 @@ public class GraphicsDisplay {
     /** Transfers the given display buffer area to the display driver */
     private void transferBuffer(int xMin, int yMin, int xMax, int yMax) {
         synchronized (lock) {
+            int xGranularity = driver.getDisplayInfo().getXGranularity();
+            xMin = (xMin / xGranularity) * xGranularity;
+            xMax = ((xMax + xGranularity - 1) / xGranularity) * xGranularity;
+
             int width = xMax - xMin;
             int height = yMax - yMin;
+
             PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
             int bitsPerRow = width * pixelFormat.getBitCount();
             int bitOffset = 0;

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -19,7 +19,7 @@ public class GraphicsDisplay {
     private int modifiedYMax = Integer.MIN_VALUE;
     private int modifiedYMin = Integer.MAX_VALUE;
     private TimerTask pendingUpdate = null;
-    private int transferDelayMillis = 20;
+    private int transferDelayMillis = 15;
     private final int displayWidth;
     private final int displayHeight;
 
@@ -50,6 +50,23 @@ public class GraphicsDisplay {
                         displayBuffer,
                         pixelAddress(xMin, targetY),
                         xMax - xMin);
+            }
+            markModified(xMin, yMin, xMax, yMax);
+        }
+    }
+
+    public void fillRect(int x, int y, int width, int height, int rgb888) {
+        synchronized (lock) {
+            int xMin = Math.max(0, x);
+            int yMin = Math.max(0, y);
+            int xMax = Math.min(x + width, displayWidth);
+            int yMax = Math.min(y + height, displayHeight);
+            if (xMax <= xMin || yMax <= yMin) {
+                return;
+            }
+            for (int targetY = yMin; targetY < yMax; targetY++) {
+                int start = pixelAddress(xMin, targetY);
+                Arrays.fill(displayBuffer, start, start + xMax - xMin, rgb888);
             }
             markModified(xMin, yMin, xMax, yMax);
         }
@@ -88,6 +105,10 @@ public class GraphicsDisplay {
         this.transferDelayMillis = millis;
     }
 
+    // Private methods. Note that internally
+    // - we assume coordinates are in range while we account for out-of-bounds coordinates in user methods.
+    // - we use min/max coordinate bounds instead of width/height as in user methods.
+
     /** Marks the given screen area as modified */
     private void markModified(int xMin, int yMin, int xMax, int yMax) {
         synchronized (lock) {
@@ -108,10 +129,6 @@ public class GraphicsDisplay {
             }
         }
     }
-
-    // Private methods. Note that internally
-    // - we assume coordinates are in range while we account for out-of-bounds coordinates in user methods.
-    // - we use min/max coordinate bounds instead of width/height as in user methods.
 
     /** Returns the address of the given pixel in the display buffer */
     private int pixelAddress(int x, int y) {
@@ -147,22 +164,4 @@ public class GraphicsDisplay {
             }
         }
     }
-
-    public void fillRect(int x, int y, int width, int height, int rgb888) {
-        synchronized (lock) {
-            int xMin = Math.max(0, x);
-            int yMin = Math.max(0, y);
-            int xMax = Math.min(x + width, displayWidth);
-            int yMax = Math.min(y + height, displayHeight);
-            if (xMax <= xMin || yMax <= yMin) {
-                return;
-            }
-            for (int targetY = yMin; targetY < yMax; targetY++) {
-                int start = pixelAddress(xMin, targetY);
-                Arrays.fill(displayBuffer, start, start + xMax - xMin, rgb888);
-            }
-            markModified(xMin, yMin, xMax, yMax);
-        }
-    }
-
 }

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplayInfo.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplayInfo.java
@@ -6,13 +6,21 @@ public class GraphicsDisplayInfo {
     private final int height;
     private final PixelFormat pixelFormat;
 
-    public GraphicsDisplayInfo(int width, int height, PixelFormat pixelFormat) {
+    /** x-coordinates must be a multiple of this value when sending data to the driver. */
+    private final int xGranularity;
+
+    public GraphicsDisplayInfo(int width, int height, PixelFormat pixelFormat, int xGranularity) {
         this.width = width;
         this.height = height;
         this.pixelFormat = pixelFormat;
+        this.xGranularity = xGranularity;
     }
 
-    /** The width of the display in pixel. */
+    public GraphicsDisplayInfo(int width, int height, PixelFormat pixelFormat) {
+        this(width, height, pixelFormat, 1);
+    }
+
+        /** The width of the display in pixel. */
     public int getWidth() {
         return width;
     }
@@ -25,4 +33,10 @@ public class GraphicsDisplayInfo {
     public PixelFormat getPixelFormat() {
         return pixelFormat;
     }
+
+    /** x-coordinates must be a multiple of this value when sending data to the driver. */
+    public int getXGranularity() {
+        return xGranularity;
+    }
+
 }

--- a/src/main/java/com/pi4j/drivers/display/graphics/PixelFormat.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/PixelFormat.java
@@ -79,20 +79,43 @@ public enum PixelFormat {
      * @param srcRgb
      *            The source array with rgb values in 24 bit integers.
      * @param srcOffset
-     *            The start offset in the soruce array
+     *            The start offset in the source array
      * @param dst
      *            The destination buffer.
      * @param dstBitOffset
-     *            The bit offset in the desitination buffer.
+     *            The bit offset in the destination buffer.
      * @param pixelCount
      *            The number of pixels to be transferred.
      *
      * @return The number of bits written.
      */
     int writeRgb(int[] srcRgb, int srcOffset, byte[] dst, int dstBitOffset, int pixelCount) {
+        return writeRgb(srcRgb, srcOffset, 1, dst, dstBitOffset, pixelCount);
+    }
+
+    /**
+     * Writes 24 bit integer RGB values from srcRgb to dst in "this" pixel format.
+     *
+     * @param srcRgb
+     *            The source array with rgb values in 24 bit integers.
+     * @param srcOffset
+     *            The start offset in the source array
+     * @param srcStride
+     *            The value to add to the start offset after each pixel.
+     * @param dst
+     *            The destination buffer.
+     * @param dstBitOffset
+     *            The bit offset in the destination buffer.
+     * @param pixelCount
+     *            The number of pixels to be transferred.
+     *
+     * @return The number of bits written.
+     */
+     int writeRgb(int[] srcRgb, int srcOffset, int srcStride, byte[] dst, int dstBitOffset, int pixelCount) {
         int bitsWritten = 0;
         for (int i = 0; i < pixelCount; i++) {
-            bitsWritten += writeRgb(srcRgb[srcOffset + i], dst, dstBitOffset + bitsWritten);
+            bitsWritten += writeRgb(srcRgb[srcOffset], dst, dstBitOffset + bitsWritten);
+            srcOffset += srcStride;
         }
         return bitsWritten;
     }

--- a/src/main/java/com/pi4j/drivers/display/graphics/st7789/St7789Driver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/st7789/St7789Driver.java
@@ -10,12 +10,16 @@ import com.pi4j.io.spi.Spi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.util.EnumSet;
+
 /*
  * Tested on Adafruit 1.54" 240x240 Wide Angle TFT LCD Display with MicroSD - ST7789 with EYESPI Connector
  * https://www.adafruit.com/product/3787
  */
 
 public class St7789Driver implements GraphicsDisplayDriver {
+
+    public static final EnumSet<PixelFormat> SUPPORTED_PIXEL_FORMATS = EnumSet.of(PixelFormat.RGB_444, PixelFormat.RGB_565);
 
     private static Logger log = LoggerFactory.getLogger(St7789Driver.class);
     private final static int WIDTH = 240;

--- a/src/test/java/com/pi4j/drivers/display/graphics/AwtGraphicsDisplayTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/AwtGraphicsDisplayTest.java
@@ -27,7 +27,7 @@ public class AwtGraphicsDisplayTest {
     @Test
     public void testRgb888toRgb444() throws IOException {
 
-        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(10, 10, PixelFormat.RGB_444));
+        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(10, 10, PixelFormat.RGB_444);
         AwtGraphicsDisplay mockDisplay = new AwtGraphicsDisplay(display);
         mockDisplay.setTransferDelayMillis(0);
 
@@ -50,7 +50,7 @@ public class AwtGraphicsDisplayTest {
     @Test
     public void testRgb888toRgb565() throws IOException {
 
-        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(10, 10, PixelFormat.RGB_565));
+        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(10, 10, PixelFormat.RGB_565);
         AwtGraphicsDisplay mockDisplay = new AwtGraphicsDisplay(display);
         mockDisplay.setTransferDelayMillis(0);
 
@@ -72,7 +72,7 @@ public class AwtGraphicsDisplayTest {
     @Test
     public void testDisplayDataBufferInt444() {
 
-        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(10, 10, PixelFormat.RGB_444));
+        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(10, 10, PixelFormat.RGB_444);
         AwtGraphicsDisplay mockDisplay = new AwtGraphicsDisplay(display);
         mockDisplay.setTransferDelayMillis(0);
 
@@ -89,7 +89,7 @@ public class AwtGraphicsDisplayTest {
     @Test
     public void testDisplayDataBufferInt565() {
 
-        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(10, 10, PixelFormat.RGB_565));
+        FakeGraphicsDisplayDriver display = new FakeGraphicsDisplayDriver(10, 10, PixelFormat.RGB_565);
         AwtGraphicsDisplay mockDisplay = new AwtGraphicsDisplay(display);
         mockDisplay.setTransferDelayMillis(0);
 

--- a/src/test/java/com/pi4j/drivers/display/graphics/FakeGraphicsDisplayDriver.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/FakeGraphicsDisplayDriver.java
@@ -2,13 +2,18 @@ package com.pi4j.drivers.display.graphics;
 
 public class FakeGraphicsDisplayDriver implements GraphicsDisplayDriver {
 
-    private byte[] data;
-    private GraphicsDisplayInfo displayInfo;
+    private final byte[] data;
+    private final GraphicsDisplayInfo displayInfo;
 
-    public FakeGraphicsDisplayDriver(GraphicsDisplayInfo displayInfo) {
-        this.displayInfo = displayInfo;
+    public FakeGraphicsDisplayDriver(int width, int height, PixelFormat pixelFormat) {
+        int xGranularity = 1;
+        while ((xGranularity * pixelFormat.getBitCount()) % 8 != 0) {
+            xGranularity *= 2;
+        }
+        this.displayInfo = new GraphicsDisplayInfo(width, height, pixelFormat, xGranularity);
         this.data = new byte[(displayInfo.getWidth() * displayInfo.getHeight()
                 * displayInfo.getPixelFormat().getBitCount() + 7) / 8];
+        checkAlignment(width, "Display width");
     }
 
     public byte[] getData() {
@@ -45,7 +50,7 @@ public class FakeGraphicsDisplayDriver implements GraphicsDisplayDriver {
     }
 
     private void checkAlignment(int x, String target) {
-        if (x * displayInfo.getPixelFormat().getBitCount() % 8 != 0) {
+        if ((x * displayInfo.getPixelFormat().getBitCount()) % 8 != 0) {
             throw new IllegalArgumentException("misaligned for " + target + " -- must be aligned on byte address");
         }
     }

--- a/src/test/java/com/pi4j/drivers/display/graphics/GraphicsDisplayTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/GraphicsDisplayTest.java
@@ -11,7 +11,7 @@ public class GraphicsDisplayTest {
     // 12 bit test
     @Test
     public void testRgb888toRgb444() throws IOException {
-        FakeGraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(100, 100, PixelFormat.RGB_444));
+        FakeGraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
         GraphicsDisplay display = new GraphicsDisplay(driver);
         display.fillRect(0, 0, 48, 1, Color.RED.getRGB());
         display.flush();
@@ -25,7 +25,7 @@ public class GraphicsDisplayTest {
     // 16 bit test
     @Test
     public void testRgb888toRgb565() throws IOException {
-        FakeGraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(100, 100, PixelFormat.RGB_565));
+        FakeGraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_565);
         GraphicsDisplay display = new GraphicsDisplay(driver);
         display.setTransferDelayMillis(0);
         display.fillRect(0, 0, 48, 1, Color.RED.getRGB());
@@ -38,7 +38,7 @@ public class GraphicsDisplayTest {
 
     @Test
     public void testSetPixel() {
-        FakeGraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(new GraphicsDisplayInfo(100, 100, PixelFormat.RGB_888));
+        FakeGraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_888);
         GraphicsDisplay display = new GraphicsDisplay(driver);
         display.setTransferDelayMillis(0);
         display.setPixel(10, 10, 0x112233);


### PR DESCRIPTION
Setting a granularity for x-coordinates will make sure we don't write to the fake driver on odd x-coordinates in RGB444 mode, which it doesn't support (and I expect drivers for monochrome screens to have similar limitations).

Also support a stride value in the pixel data transfer method, which we'll need to implement screen rotation in 90° steps.