### PR TITLE
Let graphics drivers implement closeable and clean up

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -2,11 +2,12 @@ package com.pi4j.drivers.display.graphics;
 
 import com.pi4j.drivers.display.BitmapFont;
 
+import java.io.Closeable;
 import java.util.Arrays;
 import java.util.Timer;
 import java.util.TimerTask;
 
-public class GraphicsDisplay {
+public class GraphicsDisplay implements Closeable {
     // TODO(https://github.com/Pi4J/pi4j/issues/475): Remove or update this limitation.
     private static final int MAX_TRANSFER_SIZE = 4000;
 
@@ -48,6 +49,12 @@ public class GraphicsDisplay {
         transferBuffer = new byte[Math.min(
                 MAX_TRANSFER_SIZE,
                 (displayWidth * displayHeight * driver.getDisplayInfo().getPixelFormat().getBitCount() + 7) / 8)];
+    }
+
+    @Override
+    public void close() {
+        flush();
+        driver.close();
     }
 
     /** Draws an image at the given coordinates */
@@ -100,6 +107,22 @@ public class GraphicsDisplay {
                 modifiedYMax = Integer.MIN_VALUE;
             }
         }
+    }
+
+    /**
+     * Returns the display height in pixels. This might differ from the driver display information, as the screen
+     * might be rotated.
+     */
+    public int getHeight() {
+        return displayHeight;
+    }
+
+    /**
+     * Returns the display width in pixels. This might differ from the driver display information, as the screen
+     * might be rotated.
+     */
+    public int getWidth() {
+        return displayWidth;
     }
 
     /**
@@ -167,7 +190,6 @@ public class GraphicsDisplay {
         }
         return w * scaleX;
     }
-
 
     /** Sets the pixel at the given coordinates to the given color */
     public void setPixel(int x, int y, int color) {
@@ -264,5 +286,4 @@ public class GraphicsDisplay {
             }
         }
     }
-
 }

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -243,6 +243,15 @@ public class GraphicsDisplay implements Closeable {
 
     /** Transfers the given display buffer area to the display driver, mapping the rotation */
     private void transferBuffer(int xMin, int yMin, int xMax, int yMax) {
+        int xGranularity = driver.getDisplayInfo().getXGranularity();
+        if (rotation == Rotation.ROTATE_0 || rotation == Rotation.ROTATE_180) {
+            xMin = (xMin / xGranularity) * xGranularity;
+            xMax = ((xMax + xGranularity - 1) / xGranularity) * xGranularity;
+        } else {
+            yMin = (yMin / xGranularity) * xGranularity;
+            yMax = ((yMax + xGranularity - 1) / xGranularity) * xGranularity;
+        }
+
         switch (rotation) {
             case ROTATE_0 ->
                 transferBuffer(pixelAddress(xMin, yMin), 1, displayWidth, xMin, yMin, xMax, yMax);
@@ -258,10 +267,6 @@ public class GraphicsDisplay implements Closeable {
     /** Transfers the given display buffer area to the display driver */
     private void transferBuffer(int sourceAddress, int sourceStrideX, int sourceStrideY, int xMin, int yMin, int xMax, int yMax) {
         synchronized (lock) {
-            int xGranularity = driver.getDisplayInfo().getXGranularity();
-            xMin = (xMin / xGranularity) * xGranularity;
-            xMax = ((xMax + xGranularity - 1) / xGranularity) * xGranularity;
-
             int width = xMax - xMin;
             int height = yMax - yMin;
 

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplayDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplayDriver.java
@@ -1,8 +1,13 @@
 package com.pi4j.drivers.display.graphics;
 
-public interface GraphicsDisplayDriver {
+import java.io.Closeable;
+
+public interface GraphicsDisplayDriver extends Closeable {
 
     GraphicsDisplayInfo getDisplayInfo();
 
     void setPixels(int x, int y, int width, int height, byte[] data);
+
+    @Override
+    void close();
 }

--- a/src/main/java/com/pi4j/drivers/display/graphics/console/ConsoleGraphicsDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/console/ConsoleGraphicsDriver.java
@@ -1,0 +1,74 @@
+package com.pi4j.drivers.display.graphics.console;
+
+import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayInfo;
+import com.pi4j.drivers.display.graphics.PixelFormat;
+
+/**
+ * A graphics driver that renders to the console, mostly for debug / testing purposes.
+ * <p>
+ * Note that this will produce artifacts unless the line height matches the character height.
+ */
+public class ConsoleGraphicsDriver implements GraphicsDisplayDriver {
+    // Screen buffer; we could get rid of this by adding y-granularity support but then would lose the
+    // render on close option.
+    private byte[] buffer;
+
+    private final GraphicsDisplayInfo displayInfo;
+    private final boolean renderOnClose;
+
+    public ConsoleGraphicsDriver(int width, int height, boolean renderOnClose) {
+        this.displayInfo = new GraphicsDisplayInfo(width, height, PixelFormat.RGB_888);
+        this.renderOnClose = renderOnClose;
+        buffer = new byte[width * height * 3];
+    }
+
+    @Override
+    public GraphicsDisplayInfo getDisplayInfo() {
+        return displayInfo;
+    }
+
+    @Override
+    public void setPixels(int x, int y, int width, int height, byte[] data) {
+        for (int i = 0; i < height; i++) {
+            System.arraycopy(data, i * width * 3, buffer, pixelAddress(x, y + i), width * 3);
+        }
+        if (!renderOnClose) {
+            render(x, y, width, height);
+        }
+    }
+
+    @Override
+    public void close() {
+        if (renderOnClose) {
+            render(0, 0, displayInfo.getWidth(), displayInfo.getHeight());
+        }
+    }
+
+    private void render(int x, int y, int width, int height) {
+        if ((y & 1) != 0) {
+            y--;
+            height++;
+        }
+        for (int i = 0; i < height; i += 2) {
+            if (!renderOnClose) {
+                System.out.print("\u001b[" + (x + 1) + ";" + ((y + i) / 2 + 1) + "H");
+            }
+            int fgPos = pixelAddress(x,  i);
+            int bgPos = pixelAddress(x, i + 1);
+            for (int j = 0; j < width; j ++) {
+                System.out.print("\u001b[48;2;" + (buffer[fgPos] & 0xff) +";" +(buffer[fgPos + 1] & 0xff) + ";" + (buffer[fgPos + 2] & 0xff) + "m");
+                System.out.print("\u001b[38;2;" + (buffer[bgPos] & 0xff) +";" +(buffer[bgPos + 1] & 0xff) + ";" + (buffer[bgPos + 2] & 0xff) + "m▄");
+                fgPos += 3;
+                bgPos += 3;
+            }
+            if (renderOnClose) {
+                System.out.println("\033[0m");
+            }
+        }
+    }
+
+    private int pixelAddress(int x, int y) {
+        return (y * displayInfo.getWidth() + x) * 3;
+    }
+}

--- a/src/main/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriver.java
@@ -6,6 +6,7 @@ import com.pi4j.drivers.display.graphics.GraphicsDisplayInfo;
 import com.pi4j.drivers.display.graphics.PixelFormat;
 import com.pi4j.io.i2c.I2C;
 
+import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;
@@ -125,6 +126,11 @@ public class CrowPi2I2cLedMatrixDriver implements GraphicsDisplayDriver {
                 throw new RuntimeException(e);
             }
         }
+    }
+
+    @Override
+    public void close() {
+        i2c.close();
     }
 
 

--- a/src/main/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriver.java
@@ -6,7 +6,6 @@ import com.pi4j.drivers.display.graphics.GraphicsDisplayInfo;
 import com.pi4j.drivers.display.graphics.PixelFormat;
 import com.pi4j.io.i2c.I2C;
 
-import java.io.IOException;
 import java.time.Instant;
 import java.time.temporal.ChronoUnit;
 import java.util.Arrays;

--- a/src/main/java/com/pi4j/drivers/display/graphics/st7789/St7789Driver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/st7789/St7789Driver.java
@@ -10,6 +10,7 @@ import com.pi4j.io.spi.Spi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import java.io.IOException;
 import java.util.EnumSet;
 
 /*
@@ -160,5 +161,11 @@ public class St7789Driver implements GraphicsDisplayDriver {
         command(RASET, yOffset + y, yOffset + y + height - 1); // Row addr set
         command(RAMWR); // write to RAM
         data(data, (width * height * displayInfo.getPixelFormat().getBitCount() + 7) / 8);
+    }
+
+    @Override
+    public void close() {
+        spi.close();
+        dc.shutdown(dc.provider().context());
     }
 }

--- a/src/main/java/com/pi4j/drivers/display/graphics/st7789/St7789Driver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/st7789/St7789Driver.java
@@ -10,7 +10,6 @@ import com.pi4j.io.spi.Spi;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.IOException;
 import java.util.EnumSet;
 
 /*

--- a/src/main/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriver.java
@@ -1,5 +1,6 @@
 package com.pi4j.drivers.display.graphics.ws281x;
 
+import com.pi4j.context.Context;
 import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
 import com.pi4j.drivers.display.graphics.GraphicsDisplayInfo;
 import com.pi4j.drivers.display.graphics.PixelFormat;
@@ -21,7 +22,8 @@ public class Ws281xDriver implements GraphicsDisplayDriver {
      * How many bits it takes to send a single bit via SPI. 4 Bit seem to be a reasonable compromise between
      * timing precision and keeping the amount of data and the frequency low. Finding a frequency that would work
      * for three bit seemed tricky, as the minimum "low" phase after the variable length bit pulse is significantly
-     * longer than the 1-bit pulse width.
+     * longer than the 1-bit pulse width. Note that this constant is just here to avoid magical numbers --
+     * changing the bit stretch will require mode code adjustments than just changing this constant.
      */
     private static final int BIT_STRETCH = 4;
     /** The baud rate the SPI channel needs to be configured to. */
@@ -31,15 +33,39 @@ public class Ws281xDriver implements GraphicsDisplayDriver {
     private final byte[] spiBuffer;
     private final GraphicsDisplayInfo displayInfo;
     private final Spi spi;
+    private final boolean zigzag;
 
     /**
-     * The baud rate of the SPI channel handed in needs to configured to SPI_BAUD.
+     * Creates a WS281x driver instance.
+     * <p>
+     * Note that the baud rate of the SPI channel handed in needs to configured to SPI_BAUD.
      * <p>
      * For two-dimensional LED strip arrangement, the driver assumes that LED index 0 is at coordinates (0,0)
-     * and the start LED index of each subsequent row is at y * width.
+     * and the start LED index of each subsequent row is at y * width. For a "zigzag" arrangement, use the
+     * other constructor.
      */
     public Ws281xDriver(Spi spi, int width, int height) {
+        this(spi, width, height, false);
+    }
+
+    /**
+     * Creates a WS281x driver instance.
+     * <p>
+     * Note that the baud rate of the SPI channel handed in needs to configured to SPI_BAUD.
+     * <p>
+     * If the zigzag parameter is set to true, for two-dimensional LED strip arrangement, the driver assumes that LED
+     * order reverses direction in each row, starting with index 0 is at coordinates (0,0).
+     */
+    public Ws281xDriver(Spi spi, int width, int height, boolean zigzag) {
         this.spi = spi;
+        this.zigzag = zigzag;
+
+        // We just check it's not the default to allow device-depending adjustments while still avoiding the
+        // most simple footgun here.
+        if (spi.config().getBaud() == Spi.DEFAULT_BAUD) {
+            throw new IllegalArgumentException("Please set the baud rate to Ws281xDriver.SPI_BAUD");
+        }
+
         spiBuffer = new byte[width * height * COLOR_CHANNELS * BIT_STRETCH];
         displayInfo = new GraphicsDisplayInfo(width, height, PixelFormat.RGB_888);
     }
@@ -54,18 +80,30 @@ public class Ws281xDriver implements GraphicsDisplayDriver {
         int src = 0;
         int lastChangedByte = 0;
         for (int i = 0; i < height; i++) {
-            int dst = ((y + i) * displayInfo.getWidth() + x) * COLOR_CHANNELS * BIT_STRETCH;
-            for (int j = 0; j < width * COLOR_CHANNELS; j++) {
-                byte b = bytes[src++];
-                for (int bitIdex = 0; bitIdex < 8; bitIdex += 2) {
-                    byte newValue = (byte) ((((b << bitIdex) & 0x80) == 0 ? 0b1000_0000 : 0b1100_0000)
-                                            | (((b << bitIdex) & 0x40) == 0 ? 0b1000 : 0b1100));
-                    if (newValue != spiBuffer[dst]) {
-                        spiBuffer[dst] = newValue;
-                        lastChangedByte = dst;
+            int dy = y + i;
+            int dst;
+            int dstStride;
+            if (zigzag && (dy & 1) == 1) {
+                dst = ((dy + 1) * displayInfo.getWidth() - x - 1) * COLOR_CHANNELS * BIT_STRETCH;
+                dstStride = -2 * COLOR_CHANNELS * BIT_STRETCH;
+            } else {
+                dst = (dy * displayInfo.getWidth() + x) * COLOR_CHANNELS * BIT_STRETCH;
+                dstStride = 0;
+            }
+            for (int j = 0; j < width; j++) {
+                for (int k = 0; k < COLOR_CHANNELS; k++) {
+                    byte b = bytes[src++];
+                    for (int bitIdex = 0; bitIdex < 8; bitIdex += 2) {
+                        byte newValue = (byte) ((((b << bitIdex) & 0x80) == 0 ? 0b1000_0000 : 0b1100_0000)
+                                | (((b << bitIdex) & 0x40) == 0 ? 0b1000 : 0b1100));
+                        if (newValue != spiBuffer[dst]) {
+                            spiBuffer[dst] = newValue;
+                            lastChangedByte = dst;
+                        }
+                        dst++;
                     }
-                    dst++;
                 }
+                dst += dstStride;
             }
         }
         // We always need to start at 0, but we only need to send up to the last changed pixel.

--- a/src/main/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriver.java
@@ -5,6 +5,8 @@ import com.pi4j.drivers.display.graphics.GraphicsDisplayInfo;
 import com.pi4j.drivers.display.graphics.PixelFormat;
 import com.pi4j.io.spi.Spi;
 
+import java.io.IOException;
+
 /**
  * Implements a driver for WS 281x LED strips using a SPI interface. Note that the baud rate of the
  * SPI channel needs to be set to SPI_BAUD.
@@ -73,5 +75,10 @@ public class Ws281xDriver implements GraphicsDisplayDriver {
         if (lastChangedPixel > 0) {
             spi.write(spiBuffer, 0, lastChangedPixel * COLOR_CHANNELS * BIT_STRETCH);
         }
+    }
+
+    @Override
+    public void close() {
+        spi.close();
     }
 }

--- a/src/main/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriver.java
@@ -1,12 +1,9 @@
 package com.pi4j.drivers.display.graphics.ws281x;
 
-import com.pi4j.context.Context;
 import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
 import com.pi4j.drivers.display.graphics.GraphicsDisplayInfo;
 import com.pi4j.drivers.display.graphics.PixelFormat;
 import com.pi4j.io.spi.Spi;
-
-import java.io.IOException;
 
 /**
  * Implements a driver for WS 281x LED strips using a SPI interface. Note that the baud rate of the

--- a/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
@@ -13,17 +13,14 @@ import java.util.Random;
 
 public abstract class AbstractGraphicsDisplayDriverTest {
     private Context pi4j;
-    private GraphicsDisplayDriver driver;
 
     @BeforeEach
     public void setUp() {
         pi4j = Pi4J.newAutoContext();
-        driver = createDriver(pi4j);
     }
 
     @AfterEach
     public void tearDown() {
-        driver.close();
         pi4j.shutdown();
     }
 
@@ -31,10 +28,9 @@ public abstract class AbstractGraphicsDisplayDriverTest {
 
     @Test
     public void testFillRect() throws InterruptedException {
-        GraphicsDisplay display = new GraphicsDisplay(driver);
-        GraphicsDisplayInfo displayInfo = driver.getDisplayInfo();
-        int width = displayInfo.getWidth();
-        int height = displayInfo.getHeight();
+        GraphicsDisplay display = new GraphicsDisplay(createDriver(pi4j));
+        int width = display.getWidth();
+        int height = display.getHeight();
         display.fillRect(0, 0, width, height, 0x0);
         Random random = new Random(0);
         for (int i = 0; i < 10; i++) {
@@ -44,41 +40,55 @@ public abstract class AbstractGraphicsDisplayDriverTest {
             int h = random.nextInt(height - y);
             int color = random.nextInt(0xffffff);
             display.fillRect(x, y, w, h, color);
-            Thread.sleep(100);
         }
-        display.flush(); // Make sure we don't get writes later.
+        display.close();
+    }
+
+    // Text makes rotation (bugs) quite obvious, so we use this to test both.
+    @Test
+    public void testBitmapFont0() throws InterruptedException {
+        renderBitmapFont(GraphicsDisplay.Rotation.ROTATE_0);
     }
 
     @Test
-    public void testBitmapFont() throws InterruptedException {
-        for (GraphicsDisplay.Rotation rotation : GraphicsDisplay.Rotation.values()) {
-            GraphicsDisplay display = new GraphicsDisplay(driver, rotation);
-            GraphicsDisplayInfo displayInfo = driver.getDisplayInfo();
-            int width = displayInfo.getWidth();
-            int height = displayInfo.getHeight();
-            display.fillRect(0, 0, width, height, 0);
+    public void testBitmapFont90() throws InterruptedException {
+        renderBitmapFont(GraphicsDisplay.Rotation.ROTATE_90);
+    }
 
-            BitmapFont font = BitmapFont.get5x8Font();
-            BitmapFont proportionalFont = BitmapFont.get5x10Font(BitmapFont.Option.PROPORTIONAL);
+    @Test
+    public void testBitmapFont180() throws InterruptedException {
+        renderBitmapFont(GraphicsDisplay.Rotation.ROTATE_180);
+    }
 
-            int textWidth = display.renderText(1, 8, "Hello Pi4J Monospaced", font, 0xff8888);
-            assertEquals("Hello Pi4J Monospaced".length() * 6, textWidth);
-            display.renderText(1, 50, "Hello Pi4j-gpqy", proportionalFont, 0x88ff88, 2, 3);
-            display.renderText(1, 100, "Hello Pi4J 3/4x", proportionalFont, 0x8888ff, 3, 4);
-            display.renderText(1, 180, "Hello Pi4J", proportionalFont, 0xffff88, 4, 7);
+    @Test
+    public void testBitmapFont270() throws InterruptedException {
+        renderBitmapFont(GraphicsDisplay.Rotation.ROTATE_270);
+    }
 
-            display.flush(); // Make sure we don't get writes later.
+    private void renderBitmapFont(GraphicsDisplay.Rotation rotation) throws InterruptedException {
+        GraphicsDisplay display = new GraphicsDisplay(createDriver(pi4j), rotation);
+        int width = display.getWidth();
+        int height = display.getHeight();
+        display.fillRect(0, 0, width, height, 0);
 
-            Thread.sleep(100);
-        }
+        BitmapFont font = BitmapFont.get5x8Font();
+        BitmapFont proportionalFont = BitmapFont.get5x10Font(BitmapFont.Option.PROPORTIONAL);
+
+        int textWidth = display.renderText(1, 8, "Hello Pi4J Monospaced", font, 0xff8888);
+        assertEquals("Hello Pi4J Monospaced".length() * 6, textWidth);
+        display.renderText(1, 50, "Hello Pi4j-gpqy", proportionalFont, 0x88ff88, 2, 3);
+        display.renderText(1, 100, "Hello Pi4J 3/4x", proportionalFont, 0x8888ff, 3, 4);
+        display.renderText(1, 180, "Hello Pi4J", proportionalFont, 0xffff88, 4, 7);
+
+        display.close();
     }
 
     @Test
     public void testSetPixel() throws InterruptedException {
-        GraphicsDisplay display = new GraphicsDisplay(driver);
-        GraphicsDisplayInfo displayInfo = driver.getDisplayInfo();
-        int width = displayInfo.getWidth();
-        int height = displayInfo.getHeight();
+        GraphicsDisplay display = new GraphicsDisplay(createDriver(pi4j));
+        display.setTransferDelayMillis(0);
+        int width = display.getWidth();
+        int height = display.getHeight();
         display.fillRect(0, 0, width, height, java.awt.Color.WHITE.getRGB() );
 
         for( int x = 0; x < width; x++ ) {
@@ -87,7 +97,7 @@ public abstract class AbstractGraphicsDisplayDriverTest {
             }
             Thread.sleep(5);
         }
-
-        display.flush(); // Make sure we don't get writes later.
+        
+        display.close();
     }
 }

--- a/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
@@ -97,7 +97,7 @@ public abstract class AbstractGraphicsDisplayDriverTest {
             }
             Thread.sleep(5);
         }
-        
+
         display.close();
     }
 }

--- a/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
@@ -13,14 +13,17 @@ import java.util.Random;
 
 public abstract class AbstractGraphicsDisplayDriverTest {
     private Context pi4j;
+    private GraphicsDisplayDriver driver;
 
     @BeforeEach
     public void setUp() {
         pi4j = Pi4J.newAutoContext();
+        driver = createDriver(pi4j);
     }
 
     @AfterEach
     public void tearDown() {
+        driver.close();
         pi4j.shutdown();
     }
 
@@ -28,7 +31,6 @@ public abstract class AbstractGraphicsDisplayDriverTest {
 
     @Test
     public void testFillRect() throws InterruptedException {
-        GraphicsDisplayDriver driver = createDriver(pi4j);
         GraphicsDisplay display = new GraphicsDisplay(driver);
         GraphicsDisplayInfo displayInfo = driver.getDisplayInfo();
         int width = displayInfo.getWidth();
@@ -49,7 +51,6 @@ public abstract class AbstractGraphicsDisplayDriverTest {
 
     @Test
     public void testBitmapFont() throws InterruptedException {
-        GraphicsDisplayDriver driver = createDriver(pi4j);
         for (GraphicsDisplay.Rotation rotation : GraphicsDisplay.Rotation.values()) {
             GraphicsDisplay display = new GraphicsDisplay(driver, rotation);
             GraphicsDisplayInfo displayInfo = driver.getDisplayInfo();
@@ -74,7 +75,6 @@ public abstract class AbstractGraphicsDisplayDriverTest {
 
     @Test
     public void testSetPixel() throws InterruptedException {
-        GraphicsDisplayDriver driver = createDriver(pi4j);
         GraphicsDisplay display = new GraphicsDisplay(driver);
         GraphicsDisplayInfo displayInfo = driver.getDisplayInfo();
         int width = displayInfo.getWidth();

--- a/src/test/java/com/pi4j/drivers/display/graphics/FakeGraphicsDisplayDriver.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/FakeGraphicsDisplayDriver.java
@@ -1,5 +1,7 @@
 package com.pi4j.drivers.display.graphics;
 
+import java.io.IOException;
+
 public class FakeGraphicsDisplayDriver implements GraphicsDisplayDriver {
 
     private final byte[] data;
@@ -43,6 +45,10 @@ public class FakeGraphicsDisplayDriver implements GraphicsDisplayDriver {
             int count = (width * pixelFormat.getBitCount() + 7) / 8;
             System.arraycopy(data, srcPos, this.data, dstPos, count);
         }
+    }
+
+    @Override
+    public void close() {
     }
 
     private void checkAlignment(int x, String target) {

--- a/src/test/java/com/pi4j/drivers/display/graphics/console/ConsoleGraphicsDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/console/ConsoleGraphicsDriverTest.java
@@ -1,19 +1,15 @@
-package com.pi4j.drivers.display.graphics.crowpi2matrix;
+package com.pi4j.drivers.display.graphics.console;
 
 import com.pi4j.context.Context;
 import com.pi4j.drivers.display.graphics.AbstractGraphicsDisplayDriverTest;
 import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
-import com.pi4j.drivers.display.graphics.ws281x.Ws281xDriver;
-import com.pi4j.io.spi.Spi;
 import org.junit.jupiter.api.Assumptions;
 
-public class CrowPi2I2cLedMatrixDriverTest extends AbstractGraphicsDisplayDriverTest {
+public class ConsoleGraphicsDriverTest extends AbstractGraphicsDisplayDriverTest {
     @Override
     public GraphicsDisplayDriver createDriver(Context pi4j) {
         try {
-            // Spi spi = pi4j.create(Spi.newConfigBuilder(pi4j).bus(0).address(0).build());
-            // return new Ws281xDriver(spi, 8, 8);
-            return new CrowPi2I2cLedMatrixDriver(pi4j);
+            return new ConsoleGraphicsDriver(64, 32, true);
         } catch (RuntimeException e) {
             // TODO(https://github.com/Pi4J/pi4j/issues/489): Catch Pi4j exceptions instead.
             Assumptions.abort("CrowPi2 I2C LED Matrix not found");

--- a/src/test/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/crowpi2matrix/CrowPi2I2cLedMatrixDriverTest.java
@@ -11,8 +11,6 @@ public class CrowPi2I2cLedMatrixDriverTest extends AbstractGraphicsDisplayDriver
     @Override
     public GraphicsDisplayDriver createDriver(Context pi4j) {
         try {
-            // Spi spi = pi4j.create(Spi.newConfigBuilder(pi4j).bus(0).address(0).build());
-            // return new Ws281xDriver(spi, 8, 8);
             return new CrowPi2I2cLedMatrixDriver(pi4j);
         } catch (RuntimeException e) {
             // TODO(https://github.com/Pi4J/pi4j/issues/489): Catch Pi4j exceptions instead.

--- a/src/test/java/com/pi4j/drivers/display/graphics/st7789/St7789DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/st7789/St7789DriverTest.java
@@ -9,10 +9,13 @@ import com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiConfigBuilder;
 import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
 
 /**
  * This test assumes the waveshare 1.3inch IPS display HAT pinout, see https://www.waveshare.com/1.3inch-lcd-hat.htm
  */
+// TODO(b/488): Re-enable when we can safely detect the chip and skip the test if absent.
+@Disabled
 public class St7789DriverTest extends AbstractGraphicsDisplayDriverTest {
     private static final int BACKLIGHT_ADDRESS = 24;
     private static final int DC_ADDRESS = 25;

--- a/src/test/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriverTest.java
@@ -1,0 +1,26 @@
+package com.pi4j.drivers.display.graphics.ws281x;
+
+import com.pi4j.context.Context;
+import com.pi4j.drivers.display.graphics.AbstractGraphicsDisplayDriverTest;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
+import com.pi4j.drivers.display.graphics.crowpi2matrix.CrowPi2I2cLedMatrixDriver;
+import com.pi4j.io.spi.Spi;
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Disabled;
+
+// We can't check in an enabled Ws281x driver test, as the chip can't be detected at runtime.
+// Enable locally by commenting out the next line
+@Disabled
+public class Ws281xDriverTest extends AbstractGraphicsDisplayDriverTest {
+    @Override
+    public GraphicsDisplayDriver createDriver(Context pi4j) {
+        try {
+            Spi spi = pi4j.create(Spi.newConfigBuilder(pi4j).bus(0).address(0).baud(Ws281xDriver.SPI_BAUD).build());
+            return new Ws281xDriver(spi, 8, 8, true);
+        } catch (Exception e) {
+            // TODO(https://github.com/Pi4J/pi4j/issues/489): Catch Pi4j exceptions instead.
+            Assumptions.abort("CrowPi2 I2C LED Matrix not found");
+            throw new RuntimeException(e);
+        }
+    }
+}


### PR DESCRIPTION
Cleanup included
- Use close in the AbstractGraphicsDisplayDriverTest
- Add width/height support and usage as the driver displayInfo doesn't reflect rotation handled in the display class

Minor changes included
- Disable the st7789 test as it seems to run now instead of throwing(?)
- Support a "zigzag" LED arrangement for WS281x
- Add a mini display driver that renders to the console