### PR TITLE
Fix various led matrix color issues

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/graphics/PixelFormat.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/PixelFormat.java
@@ -3,7 +3,8 @@ package com.pi4j.drivers.display.graphics;
 public enum PixelFormat {
 
     RGB_444(4, 4, 4), // 12-bit color format with 4 bits for each color channel (red, green, blue)
-    RGB_565(5, 6, 5), // 16-bit color format that uses 5 bits for red, 6 bits for green, and 5 bits for blue
+    RGB_565(5, 6, 5),
+    RGB_565_LE(5, 6, 5), // 16-bit color format that uses 5 bits for red, 6 bits for green, and 5 bits for blue
     RGB_888(8, 8, 8);
 
     private final int redBitCount;
@@ -43,15 +44,21 @@ public enum PixelFormat {
      */
     private void writeBits(int value, int count, byte[] buffer, int bitOffset) {
         int byteOffset = bitOffset / 8;
-        bitOffset %= 8;
-        int mask = ((1 << count) - 1) << (32 - count - bitOffset);
 
-        value <<= (32 - count - bitOffset);
-        while (mask != 0) {
-            buffer[byteOffset] = (byte) ((buffer[byteOffset] & ~(mask >> 24)) | (value >> 24));
-            byteOffset++;
-            value <<= 8;
-            mask <<= 8;
+        if (this == RGB_565_LE) {
+            buffer[byteOffset] = (byte) value;
+            buffer[byteOffset + 1] = (byte) (value >>> 8);
+        } else {
+            bitOffset %= 8;
+            int mask = ((1 << count) - 1) << (32 - count - bitOffset);
+
+            value <<= (32 - count - bitOffset);
+            while (mask != 0) {
+                buffer[byteOffset] = (byte) ((buffer[byteOffset] & ~(mask >> 24)) | (value >> 24));
+                byteOffset++;
+                value <<= 8;
+                mask <<= 8;
+            }
         }
     }
 

--- a/src/main/java/com/pi4j/drivers/display/graphics/PixelFormat.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/PixelFormat.java
@@ -3,9 +3,9 @@ package com.pi4j.drivers.display.graphics;
 public enum PixelFormat {
 
     RGB_444(4, 4, 4), // 12-bit color format with 4 bits for each color channel (red, green, blue)
-    RGB_565(5, 6, 5),
-    RGB_565_LE(5, 6, 5), // 16-bit color format that uses 5 bits for red, 6 bits for green, and 5 bits for blue
-    RGB_888(8, 8, 8);
+    RGB_565(5, 6, 5), // 16-bit color format that uses 5 bits for red, 6 bits for green, and 5 bits for blue
+    RGB_565_LE(5, 6, 5), // The same as RGB_565, but the bytes swapped to little endian format.
+    RGB_888(8, 8, 8); // One byte for each channel.
 
     private final int redBitCount;
     private final int greenBitCount;

--- a/src/main/java/com/pi4j/drivers/display/graphics/framebuffer/FramebufferDriver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/framebuffer/FramebufferDriver.java
@@ -33,7 +33,7 @@ public class FramebufferDriver implements GraphicsDisplayDriver, Closeable {
     }
 
     public static GraphicsDisplayDriver forSenseHat() {
-        return new FramebufferDriver(resolveFramebufferName(SENSE_HAT_FB_NAME), 8, 8, PixelFormat.RGB_565);
+        return new FramebufferDriver(resolveFramebufferName(SENSE_HAT_FB_NAME), 8, 8, PixelFormat.RGB_565_LE);
     }
 
     public FramebufferDriver(String filename, int width, int height, PixelFormat pixelFormat) {

--- a/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/AbstractGraphicsDisplayDriverTest.java
@@ -29,6 +29,7 @@ public abstract class AbstractGraphicsDisplayDriverTest {
     @Test
     public void testFillRect() throws InterruptedException {
         GraphicsDisplay display = new GraphicsDisplay(createDriver(pi4j));
+        display.setTransferDelayMillis(0);
         int width = display.getWidth();
         int height = display.getHeight();
         display.fillRect(0, 0, width, height, 0x0);
@@ -83,6 +84,12 @@ public abstract class AbstractGraphicsDisplayDriverTest {
         display.close();
     }
 
+    /**
+     * Renders rainbow colors from red on the left to violet on the right
+     * with the brightness starting at 0.1 at the top, increasing to 1 at the bottom
+     * <p>
+     * This should allow for checking color, orientation and brightness correctness.
+     */
     @Test
     public void testSetPixel() throws InterruptedException {
         GraphicsDisplay display = new GraphicsDisplay(createDriver(pi4j));
@@ -93,7 +100,9 @@ public abstract class AbstractGraphicsDisplayDriverTest {
 
         for( int x = 0; x < width; x++ ) {
             for( int y = 0; y < height; y++ ) {
-                display.setPixel( x, y, java.awt.Color.HSBtoRGB((1f * (x + height - y)) / (width + height), 1, 1));
+                display.setPixel(x, y,
+                        java.awt.Color.HSBtoRGB((1f * x) / width, 1, (0.8f * y) / height + 0.2f)
+                );
             }
             Thread.sleep(5);
         }

--- a/src/test/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriverTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/ws281x/Ws281xDriverTest.java
@@ -16,7 +16,7 @@ public class Ws281xDriverTest extends AbstractGraphicsDisplayDriverTest {
     public GraphicsDisplayDriver createDriver(Context pi4j) {
         try {
             Spi spi = pi4j.create(Spi.newConfigBuilder(pi4j).bus(0).address(0).baud(Ws281xDriver.SPI_BAUD).build());
-            return new Ws281xDriver(spi, 8, 8, true);
+            return new Ws281xDriver(spi, 8, 8, Ws281xDriver.Pattern.ZIGZAG);
         } catch (Exception e) {
             // TODO(https://github.com/Pi4J/pi4j/issues/489): Catch Pi4j exceptions instead.
             Assumptions.abort("CrowPi2 I2C LED Matrix not found");


### PR DESCRIPTION
- The SenseHat needs RGB 565 in little endian
- Ws281x uses GRB instead of RGB
- Improve the graphics test to make such issues more obvious 
- Support user supplied LED arrangements (e.g. for combining multiple matrixes in sequence)
- Make sure there is some time between WS281 updates