### PR TITLE
Add FFM plugin and limit plugin dependencies to tests 

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -56,20 +56,10 @@
             <version>${pi4j.version}</version>
         </dependency>
 
-        <!-- Pi4J Plugins (Platforms and I/O Providers) -->
+        <!-- Pi4J FFM Plugins (Platform and I/O Provider) -->
         <dependency>
             <groupId>com.pi4j</groupId>
-            <artifactId>pi4j-plugin-raspberrypi</artifactId>
-            <version>${pi4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.pi4j</groupId>
-            <artifactId>pi4j-plugin-gpiod</artifactId>
-            <version>${pi4j.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>com.pi4j</groupId>
-            <artifactId>pi4j-plugin-linuxfs</artifactId>
+            <artifactId>pi4j-plugin-ffm</artifactId>
             <version>${pi4j.version}</version>
         </dependency>
 

--- a/pom.xml
+++ b/pom.xml
@@ -56,11 +56,36 @@
             <version>${pi4j.version}</version>
         </dependency>
 
-        <!-- Pi4J FFM Plugins (Platform and I/O Provider) -->
+        <!-- Pi4J Plugins (Platform and I/O Provider), only included for testing -->
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-raspberrypi</artifactId>
+            <version>${pi4j.version}</version>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>com.pi4j</groupId>
             <artifactId>pi4j-plugin-ffm</artifactId>
             <version>${pi4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-gpiod</artifactId>
+            <version>${pi4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-linuxfs</artifactId>
+            <version>${pi4j.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.pi4j</groupId>
+            <artifactId>pi4j-plugin-pigpio</artifactId>
+            <version>${pi4j.version}</version>
+            <scope>test</scope>
         </dependency>
 
         <!-- Testing -->

--- a/src/main/java/com/pi4j/drivers/sensor/SensorDescriptor.java
+++ b/src/main/java/com/pi4j/drivers/sensor/SensorDescriptor.java
@@ -153,5 +153,4 @@ public class SensorDescriptor {
         /** Temperature in degree Celsius */
         TEMPERATURE,
     }
-
 }


### PR DESCRIPTION
I propose to only use the FFM plugin in the drivers project. This to avoid confusing for JBang projects which use this library.