### PR TITLE
Fix text positioning and the transfer buffer size for large displays

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/graphics/Graphics.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/Graphics.java
@@ -67,7 +67,7 @@ public class Graphics {
             return font.getCellWidth();
         }
         int bitOffset = glyph.getData(glyphBuffer);
-        int h = font.getCellHeight();
+        int h = font.getCellHeight() * textScaleY;
         boolean saveProcessAlpha = processAlpha;
         textPalette[1] = processAlpha ? color : (color | 0xff000000);
         processAlpha = true;

--- a/src/main/java/com/pi4j/drivers/display/graphics/Graphics.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/Graphics.java
@@ -71,7 +71,7 @@ public class Graphics {
         boolean saveProcessAlpha = processAlpha;
         textPalette[1] = processAlpha ? color : (color | 0xff000000);
         processAlpha = true;
-        drawIndexed(x, y - h, font.getCellWidth() * textScaleX, h * textScaleY, glyphBuffer, 1, textPalette, bitOffset, 1, font.getCellWidth(), textScaleX, textScaleY);
+        drawIndexed(x, y - h, font.getCellWidth() * textScaleX, h, glyphBuffer, 1, textPalette, bitOffset, 1, font.getCellWidth(), textScaleX, textScaleY);
         processAlpha = saveProcessAlpha;
         return font.getCellWidth() * textScaleX;
     }

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -298,9 +298,11 @@ public class GraphicsDisplay {
             this.y0 = y0;
             this.driver = driver;
             this.rotation = rotation;
+            int bitsPerRow = driver.getDisplayInfo().getWidth() * driver.getDisplayInfo().getPixelFormat().getBitCount();
+            // We limit the transfer size to 4000 bytes, but at least a full row of pixels
             this.transferBuffer = new byte[Math.min(
-                    MAX_TRANSFER_SIZE,
-                    (driver.getDisplayInfo().getWidth() * driver.getDisplayInfo().getHeight() * driver.getDisplayInfo().getPixelFormat().getBitCount() + 7) / 8)];
+                    Math.max(MAX_TRANSFER_SIZE, (bitsPerRow + 7) / 8),
+                    (bitsPerRow * driver.getDisplayInfo().getHeight() + 7) / 8)];
         }
 
         private void transferBuffer(int xMin, int yMin, int xMax, int yMax) {


### PR DESCRIPTION
- Text positioning did not take scaling into account
- Bug #113: Transfer buffer needs to cover at least one row of the display