### PR TITLE
Add missing MCP23008 configuration calls

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/character/hd44780/Hd44780Driver.java
+++ b/src/main/java/com/pi4j/drivers/display/character/hd44780/Hd44780Driver.java
@@ -1,6 +1,7 @@
 package com.pi4j.drivers.display.character.hd44780;
 
 import com.pi4j.drivers.display.character.CharacterDisplay;
+import com.pi4j.drivers.io.expander.ConfigurableIoExpander;
 import com.pi4j.drivers.io.expander.mcp23008.Mcp23008Driver;
 import com.pi4j.io.OnOffWrite;
 import com.pi4j.io.i2c.I2C;
@@ -128,7 +129,7 @@ public class Hd44780Driver implements CharacterDisplay {
      */
     public static Hd44780Driver withMcp23008Connection(I2C i2c, int width, int height) {
         Mcp23008Driver mcp23008 = new Mcp23008Driver(i2c);
-        mcp23008.setIoDir(0); // All pins configured for output.
+        mcp23008.setIoDirections(0xf, ConfigurableIoExpander.Direction.OUTPUT); // All pins configured for output.
         mcp23008.setOutputTriggerMask(0b0100);
         mcp23008.setOutputState(0);
         return with4BitConnection(

--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractConfigurableIoExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractConfigurableIoExpander.java
@@ -1,6 +1,9 @@
 package com.pi4j.drivers.io.expander;
 
-public abstract class AbstractConfigurableIoExpander extends AbstractInputExpander implements ConfigurableIOExpander {
+import com.pi4j.io.ListenableOnOffRead;
+import com.pi4j.io.OnOffWrite;
+
+public abstract class AbstractConfigurableIoExpander extends AbstractInputExpander implements ConfigurableIoExpander {
 
     private final OnOffWrite<?>[] onOffWriteArray;
 
@@ -8,7 +11,7 @@ public abstract class AbstractConfigurableIoExpander extends AbstractInputExpand
     private int outputBits = -1;
     private int triggerMask = -1;
 
-    public AbstractOutputExpander(int size, ListenableOnOffRead<?> interruptPin) {
+    public AbstractConfigurableIoExpander(int size, ListenableOnOffRead<?> interruptPin) {
         super(size, interruptPin);
         this.onOffWriteArray = new OnOffWrite[size];
         for (int i = 0; i < size; i++) {
@@ -41,11 +44,11 @@ public abstract class AbstractConfigurableIoExpander extends AbstractInputExpand
         int changedBits = outputBits ^ bits;
         outputBits = bits;
         if ((changedBits & triggerMask) != 0) {
-            writeOutputImpl(outputBits);
+            writeOutputsImpl(outputBits);
         }
     }
 
-    abstract protected void writeOutputImpl(int bits);
+    abstract protected void writeOutputsImpl(int bits);
 
     private class OnOffWriteImpl implements OnOffWrite<OnOffWriteImpl> {
         final int index;
@@ -55,14 +58,14 @@ public abstract class AbstractConfigurableIoExpander extends AbstractInputExpand
         }
 
         @Override
-        public OnOffWriteImpl on() throws IOException {
-            AbstractOutputExpander.this.setOutputState(index, true);
+        public OnOffWriteImpl on() {
+            AbstractConfigurableIoExpander.this.setOutputState(index, true);
             return this;
         }
 
         @Override
-        public OnOffWriteImpl off() throws IOException {
-            AbstractOutputExpander.this.setOutputState(index, false);
+        public OnOffWriteImpl off()  {
+            AbstractConfigurableIoExpander.this.setOutputState(index, false);
             return this;
         }
     }

--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractConfigurableIoExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractConfigurableIoExpander.java
@@ -1,0 +1,70 @@
+package com.pi4j.drivers.io.expander;
+
+public abstract class AbstractConfigurableIoExpander extends AbstractInputExpander implements ConfigurableIOExpander {
+
+    private final OnOffWrite<?>[] onOffWriteArray;
+
+    // At power on, the I/Os are high.
+    private int outputBits = -1;
+    private int triggerMask = -1;
+
+    public AbstractOutputExpander(int size, ListenableOnOffRead<?> interruptPin) {
+        super(size, interruptPin);
+        this.onOffWriteArray = new OnOffWrite[size];
+        for (int i = 0; i < size; i++) {
+            onOffWriteArray[i] = new OnOffWriteImpl(i);
+        }
+    }
+
+    @Override
+    public void setOutputTriggerMask(int mask) {
+        this.triggerMask = mask;
+    }
+
+    @Override
+    public OnOffWrite<?> getOutput(int index) {
+        return onOffWriteArray[index];
+    }
+
+    @Override
+    public void setOutputState(int index, boolean state) {
+        int mask = 1 << index;
+        if (state) {
+            setOutputState(outputBits | mask);
+        } else {
+            setOutputState(outputBits & ~mask);
+        }
+    }
+
+    @Override
+    public void setOutputState(int bits) {
+        int changedBits = outputBits ^ bits;
+        outputBits = bits;
+        if ((changedBits & triggerMask) != 0) {
+            writeOutputImpl(outputBits);
+        }
+    }
+
+    abstract protected void writeOutputImpl(int bits);
+
+    private class OnOffWriteImpl implements OnOffWrite<OnOffWriteImpl> {
+        final int index;
+
+        OnOffWriteImpl(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public OnOffWriteImpl on() throws IOException {
+            AbstractOutputExpander.this.setOutputState(index, true);
+            return this;
+        }
+
+        @Override
+        public OnOffWriteImpl off() throws IOException {
+            AbstractOutputExpander.this.setOutputState(index, false);
+            return this;
+        }
+    }
+
+}

--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractInputExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractInputExpander.java
@@ -1,0 +1,79 @@
+package com.pi4j.drivers.io.expander;
+
+import com.pi4j.io.ListenableOnOffRead;
+
+/**
+ * An abstract base implementation of an input expander.
+ */
+public abstract class AbstractInputExpander implements InputExpander, Closeable {
+    private final ListenableOnOffRead.Impl[] inputs
+    private final ListenableOnOffRead<?> interruptPin;
+    private final List<IntConsumer> inputStateListeners = new ArrayList<>();
+    private final int size;
+    private int inputState;
+
+    protected AbstractInputExpander(int size, ListenableOnOffRead<?> interruptPin) {
+        this.size = size;
+        this.inputs = new ListenableOnOffRead.Impl[size];
+        for (int i = 0; i < size; i++) {
+            inputs[i] = new ListenableOnOffRead.Impl();
+        }
+        if (interruptPin != null) {
+            interruptPin.addConsumer(value -> {
+                if (value) {
+                    poll();
+                }
+            });
+        }
+
+        public final int getSize() {
+            return size
+        }
+
+        /** Adds a listener that will be notified on a state change on any of the pins */
+        @Override
+        public final void addInputStateListener(IntConsumer listener) {
+            inputStateListeners.add(listener);
+        }
+
+
+        @Override
+        public final ListenableOnOffRead<ListenableOnOffRead.Impl> getInput(int index) {
+            return inputs[index];
+        }
+
+
+        @Override
+        public final int getInputState() {
+            return inputState;
+        }
+
+
+        @Override
+        public final int poll() {
+            int newState = readState();
+            if (newState != inputState) {
+                this.inputState = newState;
+                for (int i = 0; i < 8; i++) {
+                    inputs[i].setState((newState & (1 << i)) != 0);
+                }
+                inputStateListeners.forEach(listener -> listener.accept(newState));
+            }
+            return newState;
+        }
+
+        @Override
+        public void close() throws IOException {
+            if (interruptPin instanceof Closeable) {
+                try {
+                    ((Closeable) interruptPin).close();
+                } catch (IOException e) {
+                    throw new com.pi4j.io.exception.IOException(e);
+                }
+            }
+        }
+
+        /** Implementations should need to only override onyl this method. */
+        abstract protected int readStateImpl();
+
+    }

--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractInputExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractInputExpander.java
@@ -2,11 +2,17 @@ package com.pi4j.drivers.io.expander;
 
 import com.pi4j.io.ListenableOnOffRead;
 
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.function.IntConsumer;
+
 /**
  * An abstract base implementation of an input expander.
  */
 public abstract class AbstractInputExpander implements InputExpander, Closeable {
-    private final ListenableOnOffRead.Impl[] inputs
+    private final ListenableOnOffRead.Impl[] inputs;
     private final ListenableOnOffRead<?> interruptPin;
     private final List<IntConsumer> inputStateListeners = new ArrayList<>();
     private final int size;
@@ -15,6 +21,7 @@ public abstract class AbstractInputExpander implements InputExpander, Closeable 
     protected AbstractInputExpander(int size, ListenableOnOffRead<?> interruptPin) {
         this.size = size;
         this.inputs = new ListenableOnOffRead.Impl[size];
+        this.interruptPin = interruptPin;
         for (int i = 0; i < size; i++) {
             inputs[i] = new ListenableOnOffRead.Impl();
         }
@@ -25,55 +32,60 @@ public abstract class AbstractInputExpander implements InputExpander, Closeable 
                 }
             });
         }
-
-        public final int getSize() {
-            return size
-        }
-
-        /** Adds a listener that will be notified on a state change on any of the pins */
-        @Override
-        public final void addInputStateListener(IntConsumer listener) {
-            inputStateListeners.add(listener);
-        }
-
-
-        @Override
-        public final ListenableOnOffRead<ListenableOnOffRead.Impl> getInput(int index) {
-            return inputs[index];
-        }
-
-
-        @Override
-        public final int getInputState() {
-            return inputState;
-        }
-
-
-        @Override
-        public final int poll() {
-            int newState = readState();
-            if (newState != inputState) {
-                this.inputState = newState;
-                for (int i = 0; i < 8; i++) {
-                    inputs[i].setState((newState & (1 << i)) != 0);
-                }
-                inputStateListeners.forEach(listener -> listener.accept(newState));
-            }
-            return newState;
-        }
-
-        @Override
-        public void close() throws IOException {
-            if (interruptPin instanceof Closeable) {
-                try {
-                    ((Closeable) interruptPin).close();
-                } catch (IOException e) {
-                    throw new com.pi4j.io.exception.IOException(e);
-                }
-            }
-        }
-
-        /** Implementations should need to only override onyl this method. */
-        abstract protected int readStateImpl();
-
     }
+
+    public final int getSize() {
+        return size;
+    }
+
+    /**
+     * Adds a listener that will be notified on a state change on any of the pins
+     */
+    @Override
+    public final void addInputStateListener(IntConsumer listener) {
+        inputStateListeners.add(listener);
+    }
+
+
+    @Override
+    public final ListenableOnOffRead<ListenableOnOffRead.Impl> getInput(int index) {
+        return inputs[index];
+    }
+
+
+    @Override
+    public final int getInputState() {
+        return inputState;
+    }
+
+
+    @Override
+    public final int poll() {
+        int newState = readInputsImpl();
+        if (newState != inputState) {
+            this.inputState = newState;
+            for (int i = 0; i < 8; i++) {
+                inputs[i].setState((newState & (1 << i)) != 0);
+            }
+            inputStateListeners.forEach(listener -> listener.accept(newState));
+        }
+        return newState;
+    }
+
+    @Override
+    public void close() {
+        if (interruptPin instanceof Closeable) {
+            try {
+                ((Closeable) interruptPin).close();
+            } catch (IOException e) {
+                throw new com.pi4j.io.exception.IOException(e);
+            }
+        }
+    }
+
+    /**
+     * Implementations should need to only override onyl this method.
+     */
+    abstract protected int readInputsImpl();
+
+}

--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractOutputExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractOutputExpander.java
@@ -1,0 +1,75 @@
+package com.pi4j.drivers.io.expander;
+
+import com.pi4j.drivers.io.expander.OutputExpander;
+import com.pi4j.io.OnOffWrite;
+import com.pi4j.io.exception.IOException;
+import com.pi4j.io.i2c.I2C;
+
+
+public class AbstractOutputExpander implements OutputExpander, Closeable {
+    private final int size;
+    private final OnOffWrite<?>[] onOffWriteArray;
+
+    // At power on, the I/Os are high.
+    private int outputBits = -1;
+    private int triggerMask = -1;
+
+    public AbstractOutputExpander(int size) {
+        this.size = size;
+        this.onOffWriteArray = new OnOffWrite[size];
+        for (int i = 0; i < size; i++) {
+            onOffWriteArray[i] = new OnOffWriteImpl(i);
+        }
+    }
+
+    @Override
+    public void setOutputTriggerMask(int mask) {
+        this.triggerMask = mask;
+    }
+
+    @Override
+    public OnOffWrite<?> getOutput(int index) {
+        return onOffWriteArray[index];
+    }
+
+    @Override
+    public void setOutputState(int index, boolean state) {
+        int mask = 1 << index;
+        if (state) {
+            setOutputState(outputBits | mask);
+        } else {
+            setOutputState(outputBits & ~mask);
+        }
+    }
+
+    @Override
+    public void setOutputState(int bits) {
+        int changedBits = outputBits ^ bits;
+        outputBits = bits;
+        if ((changedBits & triggerMask) != 0) {
+            writeOutputImpl(outputBits);
+        }
+    }
+
+    abstract protected void writeOutputImpl(int bits);
+
+    private class OnOffWriteImpl implements OnOffWrite<OnOffWriteImpl> {
+        final int index;
+
+        OnOffWriteImpl(int index) {
+            this.index = index;
+        }
+
+        @Override
+        public OnOffWriteImpl on() throws IOException {
+            AbstractOutputExpander.this.setOutputState(index, true);
+            return this;
+        }
+
+        @Override
+        public OnOffWriteImpl off() throws IOException {
+            AbstractOutputExpander.this.setOutputState(index, false);
+            return this;
+        }
+    }
+}

--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractOutputExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractOutputExpander.java
@@ -1,12 +1,8 @@
 package com.pi4j.drivers.io.expander;
 
-import com.pi4j.drivers.io.expander.OutputExpander;
 import com.pi4j.io.OnOffWrite;
-import com.pi4j.io.exception.IOException;
-import com.pi4j.io.i2c.I2C;
 
-
-public class AbstractOutputExpander implements OutputExpander, Closeable {
+public abstract class AbstractOutputExpander implements OutputExpander {
     private final int size;
     private final OnOffWrite<?>[] onOffWriteArray;
 
@@ -47,11 +43,15 @@ public class AbstractOutputExpander implements OutputExpander, Closeable {
         int changedBits = outputBits ^ bits;
         outputBits = bits;
         if ((changedBits & triggerMask) != 0) {
-            writeOutputImpl(outputBits);
+            writeOutputsImpl(outputBits);
         }
     }
 
-    abstract protected void writeOutputImpl(int bits);
+    public int getSize() {
+        return size;
+    }
+
+    protected abstract void writeOutputsImpl(int bits);
 
     private class OnOffWriteImpl implements OnOffWrite<OnOffWriteImpl> {
         final int index;
@@ -61,13 +61,13 @@ public class AbstractOutputExpander implements OutputExpander, Closeable {
         }
 
         @Override
-        public OnOffWriteImpl on() throws IOException {
+        public OnOffWriteImpl on() {
             AbstractOutputExpander.this.setOutputState(index, true);
             return this;
         }
 
         @Override
-        public OnOffWriteImpl off() throws IOException {
+        public OnOffWriteImpl off() {
             AbstractOutputExpander.this.setOutputState(index, false);
             return this;
         }

--- a/src/main/java/com/pi4j/drivers/io/expander/ConfigurableIoExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/ConfigurableIoExpander.java
@@ -1,9 +1,9 @@
 package com.pi4j.drivers.io.expander;
 
 /** An IO expander where the direction (input or output) is configurable. */
-interface ConfigurableIoExpander implements InputExpander, OutputExpander {
+public interface ConfigurableIoExpander extends InputExpander, OutputExpander {
 
-    /** Sets the IO direction for the given pin number. */
+    /** Sets the IO direction for the given pin number (0..size). */
     default void setIoDirection(int pin, Direction direction) {
         setIoDirections(1 << pin, direction);
     }

--- a/src/main/java/com/pi4j/drivers/io/expander/ConfigurableIoExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/ConfigurableIoExpander.java
@@ -1,0 +1,20 @@
+package com.pi4j.drivers.io.expander;
+
+/** An IO expander where the direction (input or output) is configurable. */
+interface ConfigurableIoExpander implements InputExpander, OutputExpander {
+
+    /** Sets the IO direction for the given pin number. */
+    default void setIoDirection(int pin, Direction direction) {
+        setIoDirections(1 << pin, direction);
+    }
+
+    /**
+     * Sets the IO direction of multiple pins at once, as indicated by the given pin mask. If the corresponding
+     * bit is 1, the given direction is applied. Other pins remain unchanged.
+     */
+    void setIoDirections(int pinMask, Direction direction);
+
+    enum Direction {
+        INPUT, OUTPUT
+    }
+}

--- a/src/main/java/com/pi4j/drivers/io/expander/InputExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/InputExpander.java
@@ -14,7 +14,7 @@ public interface InputExpander {
     /**
      * Returns the input state of all inputs encode in an integer (for each input that is on, the corresponding bit is
      * set. Note that this returns the current internal state and does not query the chip. If no interrupt line
-     * is set up, please use poll() to request an updated state from the chip. $
+     * is set up, please use poll() to request an updated state from the chip.
      */
     int getInputState();
 
@@ -22,4 +22,8 @@ public interface InputExpander {
      * Reads the current state from the chip, updates the internal state and notifies all listeners.
      */
     int poll();
+
+    /** Returns the number of pins. */
+    int getSize();
+
 }

--- a/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
@@ -1,8 +1,7 @@
 package com.pi4j.drivers.io.expander.mcp23008;
 
-import com.pi4j.drivers.io.expander.OutputExpander;
-import com.pi4j.io.OnOffWrite;
-import com.pi4j.io.exception.IOException;
+import com.pi4j.drivers.io.expander.AbstractConfigurableIoExpander;
+import com.pi4j.io.ListenableOnOffRead;
 import com.pi4j.io.i2c.I2C;
 
 /**
@@ -15,7 +14,7 @@ import com.pi4j.io.i2c.I2C;
  * Datasheet:
  * https://ww1.microchip.com/downloads/aemDocuments/documents/APID/ProductDocuments/DataSheets/MCP23008-MCP23S08-Data-Sheet-DS20001919.pdf
  */
-public class Mcp23008Driver implements OutputExpander {
+public class Mcp23008Driver extends AbstractConfigurableIoExpander {
 
     /** Contains the bit mask for SEQOP (1<<5) used in the setIoConfiguration() call. */
     public static final int SEQOP = 1 << 5;
@@ -31,7 +30,8 @@ public class Mcp23008Driver implements OutputExpander {
     private final I2C i2c;
 
     public Mcp23008Driver(I2C i2c) {
-        this(i2c, null)
+        this(i2c, null);
+    }
 
     public Mcp23008Driver(I2C i2c, ListenableOnOffRead<?> interruptPin) {
         super(8, interruptPin);
@@ -76,8 +76,8 @@ public class Mcp23008Driver implements OutputExpander {
       * Reads the pin polarity for all pins by reading the "IPOL" register. If a bit is set, the corresponding GPIO
       * register will reflect the inverted value on the pin.
       */
-    public int getInputPolatity() {
-        return i2c.readRegsiter(Register.IPOL, pins);
+    public int getInputPolarity() {
+        return i2c.readRegister(Register.IPOL);
     }
 
     /**
@@ -93,8 +93,8 @@ public class Mcp23008Driver implements OutputExpander {
      */
     public void setInterruptModes(int pinMask, InterruptMode mode) {
         int interruptEnabled = i2c.readRegister(Register.GPINTEN);
-        if (mode == InterruptMode.OFF)
-            i2c.writeRegister(Register.GPINTEN, interruptEnabled & !pinMask);
+        if (mode == InterruptMode.OFF) {
+            i2c.writeRegister(Register.GPINTEN, interruptEnabled & ~pinMask);
         } else {
             i2c.writeRegister(Register.GPINTEN, interruptEnabled | pinMask);
             int interruptOnChange = i2c.readRegister(Register.INTCON);
@@ -146,8 +146,8 @@ public class Mcp23008Driver implements OutputExpander {
     }
 
     /** Returns the current IO configuration; please refer to setIoConfiguration for details. */
-    public void getIoConfiguration() {
-        return i2c.readRegister(Register.IOCON, config);
+    public int getIoConfiguration() {
+        return i2c.readRegister(Register.IOCON);
     }
 
     /**
@@ -176,12 +176,23 @@ public class Mcp23008Driver implements OutputExpander {
      */
     @Deprecated
     public void setIoDir(int ioDir) {
-       i2c.writeRegister(Register.IODIR, pins);
+       i2c.writeRegister(Register.IODIR, ioDir);
+    }
+
+
+    @Override
+    protected void writeOutputsImpl(int bits) {
+        i2c.writeRegister(Register.GPIO, bits);
     }
 
     @Override
-    protected void writeOutputImpl() {
-        i2c.writeRegister(Register.GPIO, outputBits);
+    protected int readInputsImpl() {
+        return i2c.readRegister(Register.GPIO);
+    }
+
+    @Override
+    public void setIoDirections(int pinMask, Direction direction) {
+
     }
 
     public enum InterruptMode {

--- a/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
@@ -8,10 +8,26 @@ import com.pi4j.io.i2c.I2C;
 /**
  * Driver for the MCP 23008 io expander. Supports output only currently.
  *
+ * Note that most configuration calls set the values for all pins simultaneously; please set the corresponding
+ * bits in the integer value accordingly; Java supports binary number representation usin a leading 0b. Alternatively,
+ * (1 << pin) can be used (where pin ranges from 0 to 7).
+ *
  * Datasheet:
  * https://ww1.microchip.com/downloads/aemDocuments/documents/APID/ProductDocuments/DataSheets/MCP23008-MCP23S08-Data-Sheet-DS20001919.pdf
  */
 public class Mcp23008Driver implements OutputExpander {
+
+    /** Contains the bit mask for SEQOP (1<<5) used in the setIoConfiguration() call. */
+    public final static int SEQOP = 1 << 5;
+    /** Contains the bit mask for DISSLW (1<<4) used in the setIoConfiguration() call. */
+    public final static int DISSLW = 1 << 4;
+    /** Contains the bit mask for HAEN (1<<3) used in the setIoConfiguration() call. */
+    public final static int HAEN = 1 << 3;
+    /** Contains the bit mask for ODR (1<<2) used in the setIoConfiguration() call. */
+    public final static int ODR = 1 << 2;
+    /** Contains the bit mask for INTPOL (1<<1) used in the setIoConfiguration() call. */
+    public final static int INTPOL = 1 << 1;
+
     private final I2C i2c;
     private final OnOffWrite<?>[] onOffWriteArray = new OnOffWrite[8];
 
@@ -26,12 +42,118 @@ public class Mcp23008Driver implements OutputExpander {
         }
     }
 
+    /**
+     * The INTF register reflects the interrupt condition on the PORT pins of any pin that is enabled for interrupts
+     * via the GPINTEN register. A ‘set’ bit indicates that the associated pin caused the interrupt.
+     */
+    public int getInterruptFlags() {
+        return i2c.readRegister(Register.INTF);
+    }
+
+    /**
+     * The INTCAP register captures the GPIO port value at the time the interrupt occurred. The register is
+     * ‘read-only’ and is updated only when an interrupt occurs. The register will remain unchanged until the
+     * interrupt is cleared via a read of the 'INTCAP' or GPIO registers..
+     */
+    public int getInterruptCapture() {
+        return i2c.readRegister(Register.INTCAP);
+    }
+
+    /**
+     * The OLAT register provides access to the output latches. A read from this register results in a read of the
+     * OLAT and not the port itself. A write to this register modifies the output latches that modify the pins
+     * configured as outputs.
+     */
+    public int getOutputLatches() {
+        return i2c.readRegister(Register.OLAT);
+    }
+
+    /**
+     * Sets the pin polarity for all pins by writing to the "IPOL" register. If a bit is set, the corresponding GPIO
+     * register will reflect the inverted value on the pin.
+     */
+    public void setInputPolarity(int pins) {
+        i2c.writeRegister(Register.IPOL, pins);
+    }
+
+    /**
+     * If a bit is set, the corresponding pin is enabled for interrupt-on-change by writing to the "GPINTEN" chip
+     * register. The "DEFVAL" and "INTCON" registers must also be configured if any pins are enabled for
+     * interrupt-on-change.
+     */
+    public void setInterruptOnChange(int pins) {
+        i2c.writeRegister(Register.GPINTEN, pins);
+    }
+
+    /**
+     * Sets the default comparison value for the associated pin by writing to the "DEFVAL" register.
+     * If enabled via the "GPINTEN" and "INTCON" registers to compare against the "DEFVAL" register, only an
+     * opposite value on the associated pin will cause an interrupt to occur.
+     */
+    public void setDefaultValues(int pins) {
+       i2c.writeRegister(Register.DEFVAL, pins);
+    }
+
+    /**
+     * Writes to the "IOCON" register, managing several bits for configuring the device:
+     *
+     * <ul>
+     * <li>Bit 5 (SEQOP) controls the incrementing function of the Address Pointer. If
+     *     the Address Pointer is disabled, the Address Pointer does not automatically increment after each byte is
+     *     clocked during a serial transfer. This feature is useful when it is desired to continuously
+     *     poll (read) or modify (write) a register. Note that this will requiring manual access to this chip,
+     *     bypassing this driver.
+     * <li>Bit 4 (DISSLW) Controls the slew rate function on the SDA pin. If enabled, the SDA
+     *     slew rate will be controlled when driving from a high to a low.
+     * <li>Bit 3 (HAEN) enables/disables the hardware address pins (A1, A0) on the MCP23S08. This bit is not used on the
+     *     MCP23008. The address pins are always enabled on the MCP23008.
+     * <li>Bit 2 (ODR) enables/disables the INT pin for open-drain configuration.
+     * <li>Bit 1 (INTPOL) sets the polarity of the INT pin. This bit is functional
+     *     only when the ODR bit is cleared, configuring the INT pin as active push-pull
+     * </ul>
+     *
+     * Bits 0 and 6-7 are unused and should be set to 0.
+     */
+    public void setIoConfiguration(int config) {
+        i2c.writeRegister(Register.IOCON, config);
+    }
+
+    /**
+     * Controls how the associated pin value is compared for the interrupt-on-change feature by writing to the
+     * "INTCON" register. If a bit is set, the corresponding I/O pin is compared against the associated bit in the
+     * DEFVAL register. If a bit value is clear, the corresponding I/O pin is compared against the previous value.
+     */
+    public void setInterruptControl(int pins) {
+        i2c.writeRegister(Register.INTCON, pins);
+    }
+
+    /**
+     * The OLAT register provides access to the output latches. A read from this register results in a read of the
+     * OLAT and not the port itself. A write to this register modifies the output latches that modify the pins
+     * configured as outputs.
+     */
+    public void setOutputLatches(int bits) {
+        return i2c.writeRegister(Register.OLAT, bits);
+    }
+
+    /**
+     * Enables the pull-up resistors for the PORT pins. If a bit is set and the corresponding pin is
+     * configured as an input, the corresponding PORT pin is internally pulled up with a 100 kOhm resistor
+     */
+    public void setPullupResistorConfiguration(int pins) {
+        i2c.writeRegister(Register.GPPU, pins);
+    }
+
+
     @Override
     public void setOutputTriggerMask(int mask) {
         this.triggerMask = mask;
     }
 
-    /** Set each bit to 0 for output and 1 for input to configure the corresponding pin. */
+    /**
+     * Set each bit to 0 for output and 1 for input to configure the corresponding pin by writing to the "IODIR"
+     * register.
+     */
     public void setIoDir(int ioDir) {
         this.ioDir = ioDir;
         i2c.writeRegister(Register.IODIR, ioDir);

--- a/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
@@ -18,15 +18,15 @@ import com.pi4j.io.i2c.I2C;
 public class Mcp23008Driver implements OutputExpander {
 
     /** Contains the bit mask for SEQOP (1<<5) used in the setIoConfiguration() call. */
-    public final static int SEQOP = 1 << 5;
+    public static final int SEQOP = 1 << 5;
     /** Contains the bit mask for DISSLW (1<<4) used in the setIoConfiguration() call. */
-    public final static int DISSLW = 1 << 4;
+    public static final int DISSLW = 1 << 4;
     /** Contains the bit mask for HAEN (1<<3) used in the setIoConfiguration() call. */
-    public final static int HAEN = 1 << 3;
+    public static final int HAEN = 1 << 3;
     /** Contains the bit mask for ODR (1<<2) used in the setIoConfiguration() call. */
-    public final static int ODR = 1 << 2;
+    public static final int ODR = 1 << 2;
     /** Contains the bit mask for INTPOL (1<<1) used in the setIoConfiguration() call. */
-    public final static int INTPOL = 1 << 1;
+    public static final int INTPOL = 1 << 1;
 
     private final I2C i2c;
     private final OnOffWrite<?>[] onOffWriteArray = new OnOffWrite[8];
@@ -34,7 +34,7 @@ public class Mcp23008Driver implements OutputExpander {
     private int outputBits = 0x0;
     private int triggerMask = -1;
     private int ioDir = -1;
-
+    
     public Mcp23008Driver(I2C i2c) {
         this.i2c = i2c;
         for (int i = 0; i < 8; i++) {

--- a/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
@@ -8,7 +8,7 @@ import com.pi4j.io.i2c.I2C;
 /**
  * Driver for the MCP 23008 io expander. Supports output only currently.
  *
- * Note that most configuration calls set the values for all pins simultaneously; please set the corresponding
+ * Note that many configuration calls set the values for all pins simultaneously; please set the corresponding
  * bits in the integer value accordingly; Java supports binary number representation usin a leading 0b. Alternatively,
  * (1 << pin) can be used (where pin ranges from 0 to 7).
  *
@@ -29,17 +29,13 @@ public class Mcp23008Driver implements OutputExpander {
     public static final int INTPOL = 1 << 1;
 
     private final I2C i2c;
-    private final OnOffWrite<?>[] onOffWriteArray = new OnOffWrite[8];
-
-    private int outputBits = 0x0;
-    private int triggerMask = -1;
-    private int ioDir = -1;
 
     public Mcp23008Driver(I2C i2c) {
+        this(i2c, null)
+
+    public Mcp23008Driver(I2C i2c, ListenableOnOffRead<?> interruptPin) {
+        super(8, interruptPin);
         this.i2c = i2c;
-        for (int i = 0; i < 8; i++) {
-            onOffWriteArray[i] = new OnOffWriteImpl(i);
-        }
     }
 
     /**
@@ -77,12 +73,43 @@ public class Mcp23008Driver implements OutputExpander {
     }
 
     /**
-     * If a bit is set, the corresponding pin is enabled for interrupt-on-change by writing to the "GPINTEN" chip
-     * register. The "DEFVAL" and "INTCON" registers must also be configured if any pins are enabled for
-     * interrupt-on-change.
+      * Reads the pin polarity for all pins by reading the "IPOL" register. If a bit is set, the corresponding GPIO
+      * register will reflect the inverted value on the pin.
+      */
+    public int getInputPolatity() {
+        return i2c.readRegsiter(Register.IPOL, pins);
+    }
+
+    /**
+     * Sets the interrupt mode for the given pin; please refer to InterruptMode for a description of the modes.
      */
-    public void setInterruptOnChange(int pins) {
-        i2c.writeRegister(Register.GPINTEN, pins);
+    public void setInterruptMode(int pin, InterruptMode mode) {
+        setInterruptModes(1 << pin, mode);
+    }
+
+    /**
+     * Sets the interrupt mode for multiple pins as indicated by the pin mask.
+     * Please refer to InterruptMode for a description of the modes.
+     */
+    public void setInterruptModes(int pinMask, InterruptMode mode) {
+        int interruptEnabled = i2c.readRegister(Register.GPINTEN);
+        if (mode == InterruptMode.OFF)
+            i2c.writeRegister(Register.GPINTEN, interruptEnabled & !pinMask);
+        } else {
+            i2c.writeRegister(Register.GPINTEN, interruptEnabled | pinMask);
+            int interruptOnChange = i2c.readRegister(Register.INTCON);
+            if (mode == InterruptMode.ON_CHANGE) {
+                i2c.writeRegister(Register.INTCON, interruptOnChange | pinMask);
+            } else {
+                i2c.writeRegister(Register.INTCON, interruptOnChange & ~pinMask);
+                int defaultValues = i2c.readRegister(Register.DEFVAL);
+                if (mode == InterruptMode.ON_0) {
+                    i2c.writeRegister(Register.DEFVAL, defaultValues | pinMask);
+                } else {
+                    i2c.writeRegister(Register.DEFVAL, defaultValues & ~pinMask);
+                }
+            }
+        }
     }
 
     /**
@@ -118,13 +145,9 @@ public class Mcp23008Driver implements OutputExpander {
         i2c.writeRegister(Register.IOCON, config);
     }
 
-    /**
-     * Controls how the associated pin value is compared for the interrupt-on-change feature by writing to the
-     * "INTCON" register. If a bit is set, the corresponding I/O pin is compared against the associated bit in the
-     * DEFVAL register. If a bit value is clear, the corresponding I/O pin is compared against the previous value.
-     */
-    public void setInterruptControl(int pins) {
-        i2c.writeRegister(Register.INTCON, pins);
+    /** Returns the current IO configuration; please refer to setIoConfiguration for details. */
+    public void getIoConfiguration() {
+        return i2c.readRegister(Register.IOCON, config);
     }
 
     /**
@@ -145,64 +168,31 @@ public class Mcp23008Driver implements OutputExpander {
     }
 
 
-    @Override
-    public void setOutputTriggerMask(int mask) {
-        this.triggerMask = mask;
-    }
-
     /**
      * Set each bit to 0 for output and 1 for input to configure the corresponding pin by writing to the "IODIR"
      * register.
+     *
+     * @deprecated Use setIoDirections instead.
      */
+    @Deprecated
     public void setIoDir(int ioDir) {
-        this.ioDir = ioDir;
-        i2c.writeRegister(Register.IODIR, ioDir);
+       i2c.writeRegister(Register.IODIR, pins);
     }
 
     @Override
-    public void setOutputState(int index, boolean state) {
-        int mask = 1 << index;
-        if ((ioDir & mask) != 0) {
-            throw new IllegalStateException("Pin " + index + " is configured for output.");
-        }
-        if (state) {
-            setOutputState(outputBits | mask);
-        } else {
-            setOutputState(outputBits & ~mask);
-        }
+    protected void writeOutputImpl() {
+        i2c.writeRegister(Register.GPIO, outputBits);
     }
 
-    @Override
-    public void setOutputState(int bits) {
-        int changedBits = outputBits ^ bits;
-        outputBits = bits;
-        if ((changedBits & triggerMask) != 0) {
-            this.i2c.writeRegister(Register.GPIO, outputBits);
-        }
+    public enum InterruptMode {
+        /** No interrupt */
+        OFF,
+        /** The interrupt pin is triggered if the value changes to 0. */
+        ON_0,
+        /** The interrupt pin is triggered if the value changes to 1. */
+        ON_1,
+        /** The interrupt pin is triggered if the value changes from the previous value. */
+        ON_CHANGE
     }
 
-    @Override
-    public OnOffWrite<?> getOutput(int index) {
-        return onOffWriteArray[index];
-    }
-
-    private class OnOffWriteImpl implements OnOffWrite<OnOffWriteImpl> {
-        final int index;
-
-        OnOffWriteImpl(int index) {
-            this.index = index;
-        }
-
-        @Override
-        public OnOffWriteImpl on() throws IOException {
-            setOutputState(index, true);
-            return this;
-        }
-
-        @Override
-        public OnOffWriteImpl off() throws IOException {
-            setOutputState(index, false);
-            return this;
-        }
-    }
 }

--- a/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
@@ -34,7 +34,7 @@ public class Mcp23008Driver implements OutputExpander {
     private int outputBits = 0x0;
     private int triggerMask = -1;
     private int ioDir = -1;
-    
+
     public Mcp23008Driver(I2C i2c) {
         this.i2c = i2c;
         for (int i = 0; i < 8; i++) {
@@ -133,7 +133,7 @@ public class Mcp23008Driver implements OutputExpander {
      * configured as outputs.
      */
     public void setOutputLatches(int bits) {
-        return i2c.writeRegister(Register.OLAT, bits);
+        i2c.writeRegister(Register.OLAT, bits);
     }
 
     /**

--- a/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
@@ -112,14 +112,6 @@ public class Mcp23008Driver extends AbstractConfigurableIoExpander {
         }
     }
 
-    /**
-     * Sets the default comparison value for the associated pin by writing to the "DEFVAL" register.
-     * If enabled via the "GPINTEN" and "INTCON" registers to compare against the "DEFVAL" register, only an
-     * opposite value on the associated pin will cause an interrupt to occur.
-     */
-    public void setDefaultValues(int pins) {
-       i2c.writeRegister(Register.DEFVAL, pins);
-    }
 
     /**
      * Writes to the "IOCON" register, managing several bits for configuring the device:
@@ -167,6 +159,13 @@ public class Mcp23008Driver extends AbstractConfigurableIoExpander {
         i2c.writeRegister(Register.GPPU, pins);
     }
 
+    /**
+     * Reads the pull-up resistor configuration. If a bit is set and the corresponding pin is
+     * configured as an input, the corresponding PORT pin is internally pulled up with a 100 kOhm resistor
+     */
+    public int getPullupResistorConfiguration() {
+        return i2c.readRegister(Register.GPPU);
+    }
 
     /**
      * Set each bit to 0 for output and 1 for input to configure the corresponding pin by writing to the "IODIR"

--- a/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Register.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Register.java
@@ -8,8 +8,8 @@ class Register {
     static final int INTCON = 4;
     static final int IOCON = 5;
     static final int GPPU = 6;
-    static final int INTF = 7;
-    static final int INTCAP = 8; // Read-only)
+    static final int INTF = 7;  // Read-only
+    static final int INTCAP = 8; // Read-only
     static final int GPIO = 9;
     static final int OLAT = 0xa;
 }

--- a/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574Constants.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574Constants.java
@@ -1,0 +1,15 @@
+package com.pi4j.drivers.io.expander.pcf8574;
+
+public class Pcf8574Constants {
+
+    /** PCF8574 and HLF8574 support a range of 8 addresses starting from 0x20 */
+    public static final int PCF8574_ADDRESS_BASE = 0x20;
+
+    /** PCF8574A supports a range of 8 addresses starting from 0x38 */
+    public static final int PCF8574A_ADDRESS_BASE = 0x38;
+
+    /** PCF8574T supports 8 addresses starting from 0x40 in increments of 2. */
+    public static final int PCF8574T_ADDRESS_BASE = 0x40;  // Odd addresses used for input
+
+    private Pcf8574Constants() {}
+}

--- a/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574InputDriver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574InputDriver.java
@@ -1,15 +1,8 @@
 package com.pi4j.drivers.io.expander.pcf8574;
 
-import com.pi4j.drivers.io.expander.InputExpander;
+import com.pi4j.drivers.io.expander.AbstractInputExpander;
 import com.pi4j.io.ListenableOnOffRead;
 import com.pi4j.io.i2c.I2C;
-
-import java.io.Closeable;
-import java.io.IOException;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.function.IntConsumer;
-
 
 /**
  * Input driver for the Pcf8574.
@@ -17,7 +10,7 @@ import java.util.function.IntConsumer;
  * As the input and output functionality of this chip uses separate addresses, it seemed most straightforward
  * to implement these as separate classes.
  */
-public class Pcf8574InputDriver extends AbstractInputDriver {
+public class Pcf8574InputDriver extends AbstractInputExpander {
     private final I2C i2c;
 
     /**
@@ -25,12 +18,12 @@ public class Pcf8574InputDriver extends AbstractInputDriver {
      * requests from the chip. If null, state changes can still be observed via the poll() method.
      */
     public Pcf8574InputDriver(I2C i2c, ListenableOnOffRead<?> interruptPin) {
-        super (8, interruptPin)
+        super (8, interruptPin);
         this.i2c = i2c;
     }
 
     @Override
-    public int poll() {
+    protected int readInputsImpl() {
         return i2c.read();
 
     }

--- a/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574InputDriver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574InputDriver.java
@@ -17,74 +17,27 @@ import java.util.function.IntConsumer;
  * As the input and output functionality of this chip uses separate addresses, it seemed most straightforward
  * to implement these as separate classes.
  */
-public class Pcf8574InputDriver implements Closeable, InputExpander {
+public class Pcf8574InputDriver extends AbstractInputDriver {
     private final I2C i2c;
-    private final ListenableOnOffRead.Impl[] inputs = new ListenableOnOffRead.Impl[8];
-    private final ListenableOnOffRead<?> interruptPin;
-    private final List<IntConsumer> inputStateListeners = new ArrayList<>();
-
-    private int inputState;
 
     /**
      * Creates a new PCF 8574 input driver. The interrupt pin will be used to trigger update
      * requests from the chip. If null, state changes can still be observed via the poll() method.
      */
     public Pcf8574InputDriver(I2C i2c, ListenableOnOffRead<?> interruptPin) {
+        super (8, interruptPin)
         this.i2c = i2c;
-        this.interruptPin = interruptPin;
-        for (int i = 0; i < 8; i++) {
-            inputs[i] = new ListenableOnOffRead.Impl();
-        }
-        if (interruptPin != null) {
-            interruptPin.addConsumer(value -> {
-                if (value) {
-                    poll();
-                }
-            });
-        }
     }
-
-    /** Adds a listener that will be notified on a state change on any of the pins */
-    @Override
-    public void addInputStateListener(IntConsumer listener) {
-        inputStateListeners.add(listener);
-    }
-
-    
-    @Override
-    public ListenableOnOffRead<ListenableOnOffRead.Impl> getInput(int index) {
-        return inputs[index];
-    }
-
-
-    @Override
-    public int getInputState() {
-        return inputState;
-    }
-
 
     @Override
     public int poll() {
-        int newState = i2c.read();
-        if (newState != inputState) {
-            this.inputState = newState;
-            for (int i = 0; i < 8; i++) {
-                inputs[i].setState((newState & (1 << i)) != 0);
-            }
-            inputStateListeners.forEach(listener -> listener.accept(newState));
-        }
-        return newState;
+        return i2c.read();
+
     }
 
     @Override
-    public void close() throws IOException {
+    public void close() {
+        super.close();
         i2c.close();
-        if (interruptPin instanceof Closeable) {
-            try {
-                ((Closeable) interruptPin).close();
-            } catch (IOException e) {
-                throw new com.pi4j.io.exception.IOException(e);
-            }
-        }
     }
 }

--- a/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574OutputDriver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574OutputDriver.java
@@ -9,76 +9,30 @@ import com.pi4j.io.i2c.I2C;
  * As the input and output functionality of this chip uses separate addresses, it seemed most straightforward
  * to implement these as separate classes.
  */
-public class Pcf8574OutputDriver implements OutputExpander {
-    /** PCF8574 and HLF8574 support a range of 8 addresses starting from 0x20 */
-    public static final int PCF8574_ADDRESS_BASE = 0x20;
+public class Pcf8574OutputDriver extends AbstractOutputExpander {
+    @Deprecated
+    public static final int PCF8574_ADDRESS_BASE = Pcf8574Constants.PCF8574_ADDRESS_BASE
 
-    /** PCF8574A supports a range of 8 addresses starting from 0x38 */
-    public static final int PCF8574A_ADDRESS_BASE = 0x38;
+    @Deprecated
+    public static final int PCF8574A_ADDRESS_BASE = Pcf8574Constants.PCF8574A_ADDRESS_BASE
 
-    /** PCF8574T supports 8 addresses starting from 0x40 in increments of 2. */
-    public static final int PCF8574T_ADDRESS_BASE = 0x40;  // Odd addresses used for input
+    @Deprecated
+    public static final int PCF8574T_ADDRESS_BASE = Pcf8574Constants.PCF8574T_ADDRESS_BASE  // Odd addresses used for input
 
     private final I2C i2c;
-    private final OnOffWrite<?>[] onOffWriteArray = new OnOffWrite[8];
-
-    // At power on, the I/Os are high.
-    private int outputBits = -1;
-    private int triggerMask = -1;
 
     public Pcf8574OutputDriver(I2C i2c) {
         this.i2c = i2c;
-        for (int i = 0; i < 8; i++) {
-            onOffWriteArray[i] = new OnOffWriteImpl(i);
-        }
     }
 
     @Override
-    public void setOutputTriggerMask(int mask) {
-        this.triggerMask = mask;
+    protected writeOutputImpl(int outputBits) {
+        i2c.write(outputBits);
     }
 
     @Override
-    public OnOffWrite<?> getOutput(int index) {
-        return onOffWriteArray[index];
-    }
-
-    @Override
-    public void setOutputState(int index, boolean state) {
-        int mask = 1 << index;
-        if (state) {
-            setOutputState(outputBits | mask);
-        } else {
-            setOutputState(outputBits & ~mask);
-        }
-    }
-
-    @Override
-    public void setOutputState(int bits) {
-        int changedBits = outputBits ^ bits;
-        outputBits = bits;
-        if ((changedBits & triggerMask) != 0) {
-            this.i2c.write(outputBits);
-        }
-    }
-
-    private class OnOffWriteImpl implements OnOffWrite<OnOffWriteImpl> {
-        final int index;
-
-        OnOffWriteImpl(int index) {
-            this.index = index;
-        }
-
-        @Override
-        public OnOffWriteImpl on() throws IOException {
-            Pcf8574OutputDriver.this.setOutputState(index, true);
-            return this;
-        }
-
-        @Override
-        public OnOffWriteImpl off() throws IOException {
-            Pcf8574OutputDriver.this.setOutputState(index, false);
-            return this;
-        }
+    public void close() {
+        super.close();
+        i2c.close();
     }
 }

--- a/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574OutputDriver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/pcf8574/Pcf8574OutputDriver.java
@@ -1,38 +1,38 @@
 package com.pi4j.drivers.io.expander.pcf8574;
 
-import com.pi4j.drivers.io.expander.OutputExpander;
-import com.pi4j.io.OnOffWrite;
-import com.pi4j.io.exception.IOException;
+import com.pi4j.drivers.io.expander.AbstractOutputExpander;
 import com.pi4j.io.i2c.I2C;
+
+import java.io.Closeable;
 
 /**
  * As the input and output functionality of this chip uses separate addresses, it seemed most straightforward
  * to implement these as separate classes.
  */
-public class Pcf8574OutputDriver extends AbstractOutputExpander {
+public class Pcf8574OutputDriver extends AbstractOutputExpander implements Closeable {
     @Deprecated
-    public static final int PCF8574_ADDRESS_BASE = Pcf8574Constants.PCF8574_ADDRESS_BASE
+    public static final int PCF8574_ADDRESS_BASE = Pcf8574Constants.PCF8574_ADDRESS_BASE;
 
     @Deprecated
-    public static final int PCF8574A_ADDRESS_BASE = Pcf8574Constants.PCF8574A_ADDRESS_BASE
+    public static final int PCF8574A_ADDRESS_BASE = Pcf8574Constants.PCF8574A_ADDRESS_BASE;
 
     @Deprecated
-    public static final int PCF8574T_ADDRESS_BASE = Pcf8574Constants.PCF8574T_ADDRESS_BASE  // Odd addresses used for input
+    public static final int PCF8574T_ADDRESS_BASE = Pcf8574Constants.PCF8574T_ADDRESS_BASE;  // Odd addresses used for input
 
     private final I2C i2c;
 
     public Pcf8574OutputDriver(I2C i2c) {
+        super(8);
         this.i2c = i2c;
     }
 
     @Override
-    protected writeOutputImpl(int outputBits) {
+    protected void writeOutputsImpl(int outputBits) {
         i2c.write(outputBits);
     }
 
     @Override
     public void close() {
-        super.close();
         i2c.close();
     }
 }


### PR DESCRIPTION
This doesn't include support for the InputExpander interface which will be in a followup, including interrupt pin wireup.