### PR TITLE
Adjustments to fix MCP230xx initial state management

### DIFF
--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractConfigurableIoExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractConfigurableIoExpander.java
@@ -7,8 +7,12 @@ public abstract class AbstractConfigurableIoExpander extends AbstractInputExpand
 
     private final OnOffWrite<?>[] onOffWriteArray;
 
-    private int outputBits = -1;
     private int triggerMask = -1;
+
+    /** Implementations are expected to obain the initial output and input state in the constructor. */
+    protected int outputStates = -1;
+    /** Implementations are expected to set this to the chip state in the constructor. */
+    protected int inputDirectionBits = -1;
 
     public AbstractConfigurableIoExpander(int size, ListenableOnOffRead<?> interruptPin) {
         super(size, interruptPin);
@@ -30,21 +34,39 @@ public abstract class AbstractConfigurableIoExpander extends AbstractInputExpand
 
     @Override
     public void setOutputStates(int mask, boolean state) {
-        if (state) {
-            setOutputState(outputBits | mask);
-        } else {
-            setOutputState(outputBits & ~mask);
-        }
+        setOutputState(state ? outputStates | mask : outputStates & ~mask);
     }
 
     @Override
     public void setOutputStates(int bits) {
-        int changedBits = outputBits ^ bits;
-        outputBits = bits;
+        int changedBits = outputStates ^ bits;
+        outputStates = bits;
         if ((changedBits & triggerMask) != 0) {
-            writeOutputsImpl(outputBits);
+            writeOutputsImpl(outputStates);
         }
     }
+
+    @Override
+    public setIoDirections(int pinMask, Direction direction) {
+        int newInputDirectionBits = direction == Direction.INPUT ? inputDirectionBits | pinMask : inputDirectionBits &~ pinMask;
+        int changedPins = newInputDirectionBits ^ inputDirectionBits;
+        if (changedPins != 0) {
+            setIoDirectionsImpl(newInputDirectionBits);
+            if (direction == Direction.INPUT) {
+                // We silently update the pins that were changed to input direction without triggering any events.
+                inputStates = inputState & ~changedPins | (readInputImpl() & changedPins);
+            } else {
+                writeOutputImpl(outputStates);
+            }
+            inputDirectionBits = newInputDirectionBits;
+        }
+    }
+
+    /**
+     * Subclasses are supposed to implement this, setting pins to input mode for bits set in inputPins and to
+     * output mode otherwise.
+     */
+    abstract protected void setIoDirectionsImpl(int inputPins);
 
     abstract protected void writeOutputsImpl(int bits);
 

--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractConfigurableIoExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractConfigurableIoExpander.java
@@ -47,16 +47,16 @@ public abstract class AbstractConfigurableIoExpander extends AbstractInputExpand
     }
 
     @Override
-    public setIoDirections(int pinMask, Direction direction) {
+    public void setIoDirections(int pinMask, Direction direction) {
         int newInputDirectionBits = direction == Direction.INPUT ? inputDirectionBits | pinMask : inputDirectionBits &~ pinMask;
         int changedPins = newInputDirectionBits ^ inputDirectionBits;
         if (changedPins != 0) {
             setIoDirectionsImpl(newInputDirectionBits);
             if (direction == Direction.INPUT) {
                 // We silently update the pins that were changed to input direction without triggering any events.
-                inputStates = inputState & ~changedPins | (readInputImpl() & changedPins);
+                inputStates = inputStates & ~changedPins | (readInputsImpl() & changedPins);
             } else {
-                writeOutputImpl(outputStates);
+                writeOutputsImpl(outputStates);
             }
             inputDirectionBits = newInputDirectionBits;
         }

--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractInputExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractInputExpander.java
@@ -16,7 +16,8 @@ public abstract class AbstractInputExpander implements InputExpander, Closeable 
     private final ListenableOnOffRead<?> interruptPin;
     private final List<IntConsumer> inputStateListeners = new ArrayList<>();
     private final int size;
-    private int inputStates;
+
+    protected int inputStates;
 
     protected AbstractInputExpander(int size, ListenableOnOffRead<?> interruptPin) {
         this.size = size;

--- a/src/main/java/com/pi4j/drivers/io/expander/AbstractOutputExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/AbstractOutputExpander.java
@@ -6,8 +6,7 @@ public abstract class AbstractOutputExpander implements OutputExpander {
     private final int size;
     private final OnOffWrite<?>[] onOffWriteArray;
 
-    // At power on, the I/Os are high.
-    private int outputBits = -1;
+    private int outputStates = -1;
     private int triggerMask = -1;
 
     public AbstractOutputExpander(int size) {
@@ -31,19 +30,15 @@ public abstract class AbstractOutputExpander implements OutputExpander {
 
     @Override
     public void setOutputStates(int mask, boolean newState) {
-        if (newState) {
-            setOutputState(outputBits | mask);
-        } else {
-            setOutputState(outputBits & ~mask);
-        }
+        setOutputStates(newState ? outputStates | mask : outputStates & ~mask);
     }
 
     @Override
     public void setOutputStates(int bits) {
-        int changedBits = outputBits ^ bits;
-        outputBits = bits;
+        int changedBits = outputStates ^ bits;
+        outputStates = bits;
         if ((changedBits & triggerMask) != 0) {
-            writeOutputsImpl(outputBits);
+            writeOutputsImpl(outputStates);
         }
     }
 

--- a/src/main/java/com/pi4j/drivers/io/expander/ConfigurableIoExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/ConfigurableIoExpander.java
@@ -8,11 +8,16 @@ public interface ConfigurableIoExpander extends InputExpander, OutputExpander {
         setIoDirections(1 << pin, direction);
     }
 
+
     /**
      * Sets the IO direction of multiple pins at once, as indicated by the given pin mask. If the corresponding
      * bit is 1, the given direction is applied. Other pins remain unchanged.
+     *
+     * Changing pins to output will send the corresponding state bit to the chip. Changing pins to
+     * input will read the corresponding state bits from the chip without triggering any events or
+     * updating any other pins. Unchanged pins will not be affected, even if they are covered by the mask.
      */
-    void setIoDirections(int pinMask, Direction direction);
+    void setIoDirections(int pinMask, Direction direction) {
 
     enum Direction {
         INPUT, OUTPUT

--- a/src/main/java/com/pi4j/drivers/io/expander/ConfigurableIoExpander.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/ConfigurableIoExpander.java
@@ -17,7 +17,7 @@ public interface ConfigurableIoExpander extends InputExpander, OutputExpander {
      * input will read the corresponding state bits from the chip without triggering any events or
      * updating any other pins. Unchanged pins will not be affected, even if they are covered by the mask.
      */
-    void setIoDirections(int pinMask, Direction direction) {
+    void setIoDirections(int pinMask, Direction direction);
 
     enum Direction {
         INPUT, OUTPUT

--- a/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
+++ b/src/main/java/com/pi4j/drivers/io/expander/mcp23008/Mcp23008Driver.java
@@ -7,6 +7,12 @@ import com.pi4j.io.i2c.I2C;
 /**
  * Driver for the MCP 23008 io expander.
  *
+ * Contains the implementation of the abstract methods from AnbstractConfigurableIoExpander and the corresponding
+ * initialization code.
+ *
+ * Additionally, this contains method to set all the configuration options and registers that are not covered
+ * by the ConfigurableIoExpander interface.
+ *
  * Note that many configuration calls set the values for all pins simultaneously; please set the corresponding
  * bits in the integer value accordingly; Java supports binary number representation using the "0b" prefix.
  * Alternatively, (1 << pin) can be used (where pin ranges from 0 to 7).
@@ -47,6 +53,8 @@ public class Mcp23008Driver extends AbstractConfigurableIoExpander {
         if (interruptPin != null) {
             setInterruptModes((1 << size) - 1, InterruptMode.ON_CHANGE);
         }
+        inputDirectionBits = readRegister(Register.IODIR);
+        inputStates = outputStates = readInputsImpl();
     }
 
     /** Protected to allow the Mcp23017 driver to write a 16-bit value */
@@ -233,18 +241,6 @@ public class Mcp23008Driver extends AbstractConfigurableIoExpander {
         return readRegister(Register.GPPU);
     }
 
-    /**
-     * Set each bit to 0 for output and 1 for input to configure the corresponding pin by writing to the "IODIR"
-     * register.
-     *
-     * @deprecated Use setIoDirections instead.
-     */
-    @Deprecated
-    public void setIoDir(int ioDir) {
-       writeRegister(Register.IODIR, ioDir);
-    }
-
-
     @Override
     protected void writeOutputsImpl(int bits) {
         writeRegister(Register.GPIO, bits);
@@ -256,9 +252,8 @@ public class Mcp23008Driver extends AbstractConfigurableIoExpander {
     }
 
     @Override
-    public void setIoDirections(int pinMask, Direction direction) {
-        int previous = readRegister(Register.IODIR);
-        writeRegister(Register.IODIR, direction == Direction.OUTPUT ? previous & ~pinMask : previous | pinMask);
+    public void setIoDirectionsImpl(int inputPins) {
+        writeRegister(Register.IODIR, inputPins);
     }
 
     public enum InterruptMode {


### PR DESCRIPTION
- Obtain the initial state in the constructor instead of assuming "something"
- When changing IO direction, perform a silent update 
- Not thoroughly tested but my traffic light example still works

I'll add some more documentation and a fix for the PCF8574 in followups.

