### PR TITLE
GraphicsTextAnimator cleanup and wireup in SenseHat

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsTextAnimator.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsTextAnimator.java
@@ -14,6 +14,7 @@ public final class GraphicsTextAnimator {
     private final int frameX;
     private final int frameY;
     private final int frameWidth;
+    private final Object lock;
 
     private BitmapFont font = BitmapFont.get5x8Font(BitmapFont.Option.PROPORTIONAL);
     private int foreground = Argb32.WHITE;
@@ -22,8 +23,9 @@ public final class GraphicsTextAnimator {
     private boolean clearOnStop = false;
     private int stepPixels = 1;
     private String text;
-
-    private Thread worker;
+    private timerTask scrollTask;
+    private Graphics graphics;
+    private int offset;
 
     public GraphicsTextAnimator(GraphicsDisplay display, String text) {
         this(display, text, 0, 0, display.getWidth());
@@ -46,6 +48,7 @@ public final class GraphicsTextAnimator {
         this.frameX = frameX;
         this.frameY = frameY;
         this.frameWidth = frameWidth;
+        this.graphics = display.getGraphics();
     }
 
     public void setText(String text) {
@@ -138,46 +141,13 @@ public final class GraphicsTextAnimator {
         return frameWidth;
     }
 
-    public void scroll() {
-        if (!running.compareAndSet(false, true)) {
-            throw new IllegalStateException("GraphicsTextAnimator is already running");
-        }
-
-        try {
-            do {
-                scrollOnce();
-            } while (running.get());
-        } finally {
-            running.set(false);
-
-            if (clearOnStop) {
-                clear();
-            }
-        }
+    /** Clears the frame and renders the text once */
+    public void render() {
+       
     }
-    
+
     public void start() {
-        if (!running.compareAndSet(false, true)) {
-            throw new IllegalStateException("GraphicsTextAnimator is already running");
-        }
 
-        worker = new Thread(() -> {
-            try {
-                do {
-                    scrollOnce();
-                } while (running.get());
-            } finally {
-                running.set(false);
-                worker = null;
-
-                if (clearOnStop) {
-                    clear();
-                }
-            }
-        }, "pi4j-graphics-text-animator");
-
-        worker.setDaemon(true);
-        worker.start();
     }
 
     public void stop() {
@@ -193,54 +163,4 @@ public final class GraphicsTextAnimator {
         return running.get();
     }
 
-    private void scrollOnce() {
-        Graphics graphics = display.getGraphics();
-        graphics.setFont(font);
-
-        int textWidth = measureTextWidth(graphics);
-
-        int startX = frameX + frameWidth;
-        int endX = frameX - textWidth;
-        int textBaseline = frameY + font.getCellHeight();
-
-        for (int x = startX; running.get() && x >= endX; x -= stepPixels) {
-            clear(graphics);
-
-            graphics.setColor(foreground);
-            graphics.renderText(x, textBaseline, text);
-
-            sleep(delay);
-        }
-    }
-
-    private int measureTextWidth(Graphics graphics) {
-        int textBaseline = frameY + font.getCellHeight();
-
-        clear(graphics);
-
-        graphics.setColor(foreground);
-        int width = graphics.renderText(frameX + frameWidth, textBaseline, text);
-
-        clear(graphics);
-
-        return width;
-    }
-
-    private void clear() {
-        clear(display.getGraphics());
-    }
-
-    private void clear(Graphics graphics) {
-        graphics.setColor(background);
-        graphics.fillRect(frameX, frameY, frameWidth, font.getCellHeight());
-    }
-
-    private void sleep(Duration duration) {
-        try {
-            Thread.sleep(duration.toMillis());
-        } catch (InterruptedException e) {
-            Thread.currentThread().interrupt();
-            running.set(false);
-        }
-    }
 }

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsTextAnimator.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsTextAnimator.java
@@ -4,17 +4,19 @@ import com.pi4j.drivers.display.BitmapFont;
 
 import java.time.Duration;
 import java.util.Objects;
-import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.Timer;
+import java.util.TimerTask;
 
+/**
+ * A class for rendering a scrolling message. Useful for showing longer texts on small displays.
+ */
 public final class GraphicsTextAnimator {
-
-    private final GraphicsDisplay display;
-    private final AtomicBoolean running = new AtomicBoolean(false);
 
     private final int frameX;
     private final int frameY;
     private final int frameWidth;
-    private final Object lock;
+    private final Object lock = new Object();
+    private final Timer timer = new Timer();
 
     private BitmapFont font = BitmapFont.get5x8Font(BitmapFont.Option.PROPORTIONAL);
     private int foreground = Argb32.WHITE;
@@ -23,14 +25,24 @@ public final class GraphicsTextAnimator {
     private boolean clearOnStop = false;
     private int stepPixels = 1;
     private String text;
-    private timerTask scrollTask;
+    private TimerTask scrollTask;
     private Graphics graphics;
     private int offset;
 
+    /**
+     * Creates a scrolling message at the top of the display, spanning the whole display width. Note that the
+     * constructor doesn't display anything (enabling detailed configuration); use start() or the methods for manual
+     * scrolling to actually display text.
+     */
     public GraphicsTextAnimator(GraphicsDisplay display, String text) {
         this(display, text, 0, 0, display.getWidth());
     }
 
+    /**
+     * Creates a scrolling message in the given frame coordinates. The frame height will be determined by
+     * the font height. Note that the constructor doesn't display anything (enabling detailed configuration);
+     * use start() or the methods for manual scrolling to actually display text.
+     */
     public GraphicsTextAnimator(
         GraphicsDisplay display,
         String text,
@@ -38,7 +50,7 @@ public final class GraphicsTextAnimator {
         int frameY,
         int frameWidth
     ) {
-        this.display = Objects.requireNonNull(display, "display must not be null");
+        this.graphics = Objects.requireNonNull(display, "display must not be null").getGraphics();
         this.text = Objects.requireNonNull(text, "text must not be null");
 
         if (frameWidth <= 0) {
@@ -48,7 +60,6 @@ public final class GraphicsTextAnimator {
         this.frameX = frameX;
         this.frameY = frameY;
         this.frameWidth = frameWidth;
-        this.graphics = display.getGraphics();
     }
 
     public void setText(String text) {
@@ -91,16 +102,25 @@ public final class GraphicsTextAnimator {
         return background;
     }
 
+    /** Sets the delay between scrolling steps. */
     public void setDelay(Duration delay) {
-        Objects.requireNonNull(delay, "delay must not be null");
+        synchronized (lock) {
+            Objects.requireNonNull(delay, "delay must not be null");
 
-        if (delay.isNegative()) {
-            throw new IllegalArgumentException("delay must not be negative");
+            if (delay.isNegative()) {
+                throw new IllegalArgumentException("delay must not be negative");
+            }
+
+            this.delay = delay;
+
+            if (isRunning()) {
+                stop();
+                start();
+            }
         }
-
-        this.delay = delay;
     }
 
+    /** Sets the delay between scrolling steps in milliseconds. */
     public void setDelayMillis(long delayMillis) {
         setDelay(Duration.ofMillis(delayMillis));
     }
@@ -141,26 +161,74 @@ public final class GraphicsTextAnimator {
         return frameWidth;
     }
 
-    /** Clears the frame and renders the text once */
-    public void render() {
-       
-    }
+    /** Clears the frame and renders the text just once. */
+    public int render() {
+        synchronized (lock) {
+            clear();
 
-    public void start() {
-
-    }
-
-    public void stop() {
-        running.set(false);
-
-        Thread currentWorker = worker;
-        if (currentWorker != null) {
-            currentWorker.interrupt();
+            // This uses clipping and the color from the last call
+            graphics.setClip(frameX, frameY, frameWidth, font.getCellHeight());
+            graphics.setColor(foreground);
+            return graphics.renderText(frameX + offset, frameY + font.getCellHeight(), text);
         }
     }
 
-    public boolean isRunning() {
-        return running.get();
+    /** Clears the frame. */
+    public void clear() {
+        synchronized (lock) {
+            graphics.setColor(background);
+            graphics.fillRect(frameX, frameY, frameWidth, font.getCellHeight());
+        }
     }
 
+    /** Clears the frame, renders the text and advances the scroll position by the configured amount of pixels. */
+    public void scroll() {
+        synchronized (lock) {
+            int textWidth = render();
+            offset -= stepPixels;
+            if (offset + textWidth < 0) {
+                offset = frameWidth;
+            }
+        }
+    }
+
+    /**
+     * Starts rendering the text asynchronously in the background. Use the stop() method to stop scrolling.
+     * Will throw an IllegalStateException when scrolling was started already.
+     */
+    public void start() {
+        synchronized (lock) {
+            if (scrollTask != null) {
+                throw new IllegalStateException("Already started.");
+            }
+            scrollTask = new TimerTask() {
+                @Override
+                public void run() {
+                        scroll();
+                }
+            };
+            long delayMs = delay.toMillis();
+            timer.schedule(scrollTask, delayMs, delayMs);
+        }
+    }
+
+    /** Stops background scrolling. This is safe to call multiple times. */
+    public void stop() {
+        synchronized (lock) {
+            if (scrollTask != null) {
+                scrollTask.cancel();
+                scrollTask = null;
+            }
+            if (clearOnStop) {
+                clear();
+            }
+        }
+    }
+
+    /** Returns true if scrolling is currently active; false otherwise. */
+    public boolean isRunning() {
+        synchronized (lock) {
+            return scrollTask != null;
+        }
+    }
 }

--- a/src/main/java/com/pi4j/drivers/hat/raspberry/SenseHat.java
+++ b/src/main/java/com/pi4j/drivers/hat/raspberry/SenseHat.java
@@ -1,13 +1,10 @@
 package com.pi4j.drivers.hat.raspberry;
 
 import com.pi4j.context.Context;
-import com.pi4j.drivers.display.graphics.GraphicsDisplay;
-import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
+import com.pi4j.drivers.display.graphics.*;
 import com.pi4j.drivers.display.graphics.GraphicsDisplay.Rotation;
 import com.pi4j.drivers.display.graphics.framebuffer.FramebufferDriver;
 import com.pi4j.drivers.display.BitmapFont;
-import com.pi4j.drivers.display.graphics.Argb32;
-import com.pi4j.drivers.display.graphics.Graphics;
 import com.pi4j.drivers.input.GameController;
 import com.pi4j.drivers.input.linux.LinuxInputDriver;
 import com.pi4j.drivers.sensor.Sensor;
@@ -34,6 +31,7 @@ public class SenseHat {
     private Tcs3400Driver tcs3400Driver;
     private Lsm9ds1Driver lsm9ds1Driver;
     private Lsm9ds1MagnetometerDriver lsm9ds1MagnetometerDriver;
+    private GraphicsTextAnimator textAnimator;
 
     private final ListenableOnOffRead.Impl up = new ListenableOnOffRead.Impl();
     private final ListenableOnOffRead.Impl down = new ListenableOnOffRead.Impl();
@@ -169,6 +167,18 @@ public class SenseHat {
         return display;
     }
 
+    /**
+     * Returns the text animator used for showMessage.
+     * Can be used to configure the scrolling message display in detail.
+     */
+    public GraphicsTextAnimator getTextAnimator() {
+        if (textAnimator == null) {
+            textAnimator = new GraphicsTextAnimator(getDisplay(), "");
+        }
+        return textAnimator;
+    }
+
+
     private void handleEvent(LinuxInputDriver.Event event) {
         if (event.getType() != LinuxInputDriver.EV_KEY) {
             return;
@@ -301,5 +311,31 @@ public class SenseHat {
             throw new IllegalArgumentException("x and y must be between 0 and 7");
         }
     }
-     
+
+    /**
+     * Shows the given scrolling message using a text animator. The message will keep scrolling in the background
+     * while the program continues execution. Use an empty string (or getTextAnimator.stop()) to stop the message.
+     */
+    public void showMessage(String message) {
+        showMessage(message, Argb32.WHITE);
+    }
+
+    /**
+     * Shows the given scrolling message in the given color using a text animator. The message will keep scrolling in
+     * the background while the program continues execution. Use an empty string (or getTextAnimator.stop()) to stop
+     * the message.
+     */
+    public void showMessage(String message, int color) {
+        GraphicsTextAnimator textAnimator = getTextAnimator();
+        if (message == null || message.isEmpty()) {
+            textAnimator.setText("");
+            textAnimator.stop();
+            return;
+        }
+        textAnimator.setText(message);
+        textAnimator.setForeground(color);
+        if (!textAnimator.isRunning()) {
+            textAnimator.start();
+        }
+    }
 }


### PR DESCRIPTION
GraphicsTextAnimator cleanup
- Switch scrolling from direct threads to a timer
- Use clipping to make sure the frame bounds are actually respected
- Operate on a single graphics instance instead of obtaining multiple

Wireup in SenseHat
- provide a simple user-friendly "showMessage" method 
- provide access to the underlying text animator for detailed configuration if desired.