### PR TITLE
Add basic support for the NAU 7802 ADC

### DIFF
--- a/src/main/java/com/pi4j/drivers/io/ad/nau7802/Constants.java
+++ b/src/main/java/com/pi4j/drivers/io/ad/nau7802/Constants.java
@@ -1,0 +1,79 @@
+package com.pi4j.drivers.io.ad.nau7802;
+
+/** Internal constants */
+class Constants {
+    static final int CAL_SUCCESS = 0;
+    static final int CAL_IN_PROGRESS = 1;
+    static final int CAL_FAILURE = 2;
+
+    static final int CALMOD_INTERNAL = 0;
+    static final int CALMOD_OFFSET = 2;
+    static final int CALMOD_GAIN = 3;
+
+    /** Register numbers */
+    static class Register {
+        static final int PU_CTRL = 0;
+        static final int CTRL1 = 1;
+        static final int CTRL2 = 2;
+        static final int OCAL1_B2 = 3;
+        static final int OCAL1_B1 = 4;
+        static final int OCAL1_B0 = 5;
+        static final int GCAL1_B3 = 6;
+        static final int GCAL1_B2 = 7;
+        static final int GCAL1_B1 = 8;
+        static final int GCAL1_B0 = 9;
+        static final int OCAL2_B2 = 10;
+        static final int OCAL2_B1 = 11;
+        static final int OCAL2_B0 = 12;
+        static final int GCAL2_B3 = 13;
+        static final int GCAL2_B2 = 14;
+        static final int GCAL2_B1 = 15;
+        static final int GCAL2_B0 = 16;
+        static final int I2C_CONTROL = 17;
+        static final int ADCO_B2 = 18;
+        static final int ADCO_B1 = 19;
+        static final int ADCO_B0 = 20;
+        static final int ADC = 0x15;
+        static final int OTP_B1 = 0x16;
+        static final int OTP_B0 = 0x17;
+        static final int PGA = 0x1B;
+        static final int PGA_PWR = 0x1C;
+        static final int DEVICE_REV = 0x1F;
+    }
+
+    /** Bit names for various registers */
+    static class Bit {
+        static final int PU_CTRL_RR = 0;
+        static final int PU_CTRL_PUD = 1;
+        static final int PU_CTRL_PUA = 2;
+        static final int PU_CTRL_PUR = 3;
+        static final int PU_CTRL_CS = 4;
+        static final int PU_CTRL_CR = 5;
+        static final int PU_CTRL_OSCS = 6;
+        static final int PU_CTRL_AVDDS = 7;
+
+        static final int CTRL1_GAIN = 2;
+        static final int CTRL1_VLDO = 5;
+        static final int CTRL1_DRDY_SEL = 6;
+        static final int CTRL1_CRP = 7;
+
+        static final int CTRL2_CALMOD = 0;
+        static final int CTRL2_CALS = 2;
+        static final int CTRL2_CAL_ERROR = 3;
+        static final int CTRL2_CRS = 4;
+        static final int CTRL2_CHS = 7;
+
+        static final int PGA_CHP_DIS = 0;
+        static final int PGA_INV = 3;
+        static final int PGA_BYPASS_EN = 4;
+        static final int PGA_OUT_EN = 5;
+        static final int PGA_LDOMODE = 6;
+        static final int PGA_RD_OTP_SEL = 7;
+
+        static final int PGA_PWR_PGA_CURR = 0;
+        static final int PGA_PWR_ADC_CURR = 2;
+        static final int PGA_PWR_MSTR_BIAS_CURR = 4;
+        static final int PGA_PWR_PGA_CAP_EN = 7;
+    }
+
+}

--- a/src/main/java/com/pi4j/drivers/io/ad/nau7802/Nau7802Driver.java
+++ b/src/main/java/com/pi4j/drivers/io/ad/nau7802/Nau7802Driver.java
@@ -1,0 +1,127 @@
+package com.pi4j.drivers.io.ad.nau7802;
+
+import com.pi4j.io.i2c.I2C;
+import com.pi4j.util.Delay;
+
+/** A basic driver for the NAU 7802 -- a special-purpose ADC for weigh scales. */
+public class Nau7802Driver {
+    public static final int I2C_ADDRESS = 0x2a;
+
+    private final Delay delay = new Delay();
+    private final I2C i2c;
+    private final byte[] buffer = new byte[3];
+
+    public Nau7802Driver(I2C i2c) {
+        this.i2c = i2c;
+    }
+
+    /** Reads a signed 24 bit analog value. */
+    public int read() {
+        i2c.readRegister(Constants.Register.ADCO_B2, buffer, 0, 3);
+        // Note that the implicit sign extension for buffer[0] below is intentional.
+        return (buffer[0] << 16) | ((buffer[1] & 0xFF) << 8) | (buffer[2] & 0xFF);
+    }
+
+    /** Resets the chip */
+    public void reset() {
+        setBit(Constants.Bit.PU_CTRL_RR, Constants.Register.PU_CTRL);
+        delay.setMillis(1).materialize();
+        clearBit(Constants.Bit.PU_CTRL_RR, Constants.Register.PU_CTRL);
+    }
+
+    /** Powers the chip up and starts measuring */
+    public void powerUp() {
+        setBit(Constants.Bit.PU_CTRL_PUD, Constants.Register.PU_CTRL);
+        setBit(Constants.Bit.PU_CTRL_PUA, Constants.Register.PU_CTRL);
+
+        for (int i = 0; i < 128; i++) {
+           if (getBit(Constants.Bit.PU_CTRL_PUR, Constants.Register.PU_CTRL)) {
+               setBit(Constants.Bit.PU_CTRL_CS, Constants.Register.PU_CTRL);
+               return;
+           }
+           delay.setMillis(1).materialize();
+        }
+        throw new IllegalStateException("Power up failed");
+    }
+
+    public void powerDown() {
+        clearBit(Constants.Bit.PU_CTRL_PUD, Constants.Register.PU_CTRL);
+        clearBit(Constants.Bit.PU_CTRL_PUA, Constants.Register.PU_CTRL);
+    }
+
+    public void setSampleRate(SampleRate sampleRate) {
+        int value = i2c.readRegister(Constants.Register.CTRL2);
+        i2c.writeRegister(Constants.Register.CTRL2, (value & 0b10001111) | (sampleRate.code << 4));
+    }
+
+    public void setChannel(Channel channel) {
+        if (channel == Channel.CHANNEL_1) {
+            clearBit(Constants.Bit.CTRL2_CHS, Constants.Register.CTRL2);
+        } else {
+            setBit(Constants.Bit.CTRL2_CHS, Constants.Register.CTRL2);
+        }
+    }
+
+    // Private Helpers
+
+    private void clearBit(int bit, int register) {
+        int value = i2c.readRegister(register);
+        i2c.writeRegister(register, value & ~(1 << bit));
+    }
+
+    private void setBit(int bit, int register) {
+        int value = i2c.readRegister(register);
+        i2c.writeRegister(register, value | (1 << bit));
+    }
+
+    private boolean getBit(int bit, int register) {
+        return (i2c.readRegister(register) & (1 << bit)) != 0;
+    }
+
+    // Public enums
+
+    public enum LowDropOut {
+        LDO_4V5,
+        LDO_4V2,
+        LDO_3V9,
+        LDO_3V6,
+        LDO_3V3,
+        LDO_3V0,
+        LDO_2V7,
+        LDO_2V4
+    }
+
+    public enum Gain {
+        GAIN_1,
+        GAIN_2,
+        GAIN_4,
+        GAIN_8,
+        GAIN_16,
+        GAIN_32,
+        GAIN_64,
+        GAIN_128
+    }
+
+    public enum Channel {
+        CHANNEL_1,
+        CHANNEL_2
+    }
+
+
+    public enum SampleRate {
+        SPS_320(0b111),
+        SPS_80(0b011),
+        SPS_40(0b010),
+        SPS_20(0b001),
+        SPS_10(0b000);
+
+        final int code;
+
+        SampleRate(int code) {
+            this.code = code;
+        }
+    }
+
+
+
+}


### PR DESCRIPTION
I bought two by mistake because they are so prominent and didn't realize they are special-purpose for weigh scales until I had written the driver.... 