### PR TITLE
Add a driver for the Semtech LR11xx LoRa transceivers

### DIFF
--- a/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121Driver.java
+++ b/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121Driver.java
@@ -1,0 +1,905 @@
+package com.pi4j.drivers.radio.lora.lr11xx;
+
+import java.io.Closeable;
+import java.time.Duration;
+import java.util.Optional;
+
+import com.pi4j.context.Context;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalInputConfigBuilder;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder;
+import com.pi4j.io.gpio.digital.DigitalState;
+import com.pi4j.io.gpio.digital.PullResistance;
+import com.pi4j.io.spi.Spi;
+import com.pi4j.io.spi.SpiChipSelect;
+import com.pi4j.io.spi.SpiConfigBuilder;
+import com.pi4j.io.spi.SpiMode;
+
+/**
+ * A Semtech LR1121 (or LR1110 / LR1120) driven over SPI.
+ *
+ * <p>Everything the chip understands is built here, in Java, on top of a
+ * {@link Lr11xxIo} that does nothing but move bytes. That split is what
+ * makes this testable: a fake transport records what was written and plays back
+ * what the radio would answer, so every command in this class is checked against
+ * the bytes Semtech's own C driver sends — without a radio, a Raspberry Pi or a
+ * soldering iron.
+ *
+ * <p>The opcodes and encodings were transcribed from that driver, which Waveshare
+ * ships with the Core1121 demo, rather than read off a datasheet. Where the two
+ * would disagree, the driver is what the hardware has actually been tested with.
+ *
+ * <h2>How the chip is spoken to</h2>
+ *
+ * Every command is a two byte big-endian opcode followed by its arguments. A
+ * command that only sets something is one SPI transaction. A command that answers
+ * is two: the command goes out, the busy line drops, and then the answer is
+ * clocked in — <b>with a status byte in front of it</b> that is not part of the
+ * response. Forgetting that byte shifts every field by one and produces values
+ * that look almost right, which is why it is handled in one place here.
+ *
+ * @see <a href="https://github.com/Lora-net/SWDR001">SWDR001, the C driver</a>
+ */
+public class Lr1121Driver implements Closeable {
+
+    // System
+    private static final int GET_STATUS = 0x0100;
+    private static final int GET_VERSION = 0x0101;
+    private static final int GET_ERRORS = 0x010D;
+    private static final int CLEAR_ERRORS = 0x010E;
+    private static final int CALIBRATE = 0x010F;
+    private static final int CALIBRATE_IMAGE = 0x0111;
+    private static final int SET_DIO_AS_RF_SWITCH = 0x0112;
+    private static final int SET_DIO_IRQ_PARAMS = 0x0113;
+    private static final int CLEAR_IRQ = 0x0114;
+    private static final int CFG_LFCLK = 0x0116;
+    private static final int SET_TCXO_MODE = 0x0117;
+    private static final int SET_STANDBY = 0x011C;
+
+    // Memory
+    private static final int WRITE_BUFFER8 = 0x0109;
+    private static final int READ_BUFFER8 = 0x010A;
+
+    // Radio
+    private static final int GET_RX_BUFFER_STATUS = 0x0203;
+    private static final int GET_PACKET_STATUS = 0x0204;
+    private static final int SET_RX = 0x0209;
+    private static final int SET_TX = 0x020A;
+    private static final int SET_RF_FREQUENCY = 0x020B;
+    private static final int SET_PACKET_TYPE = 0x020E;
+    private static final int SET_MODULATION_PARAMS = 0x020F;
+    private static final int SET_PACKET_PARAMS = 0x0210;
+    private static final int SET_TX_PARAMS = 0x0211;
+    private static final int SET_PA_CONFIG = 0x0215;
+    private static final int SET_LORA_SYNC_WORD = 0x022B;
+
+    private static final int PACKET_TYPE_LORA = 0x02;
+    private static final int LFCLK_XTAL = 0x01;
+    private static final int STANDBY_RC = 0x00;
+
+    /** Every calibration block: oscillators, PLL, ADC and image. */
+    private static final int CALIBRATE_ALL = 0x3F;
+
+    public static final int IRQ_TX_DONE = 1 << 2;
+    public static final int IRQ_RX_DONE = 1 << 3;
+    public static final int IRQ_HEADER_ERROR = 1 << 6;
+    public static final int IRQ_CRC_ERROR = 1 << 7;
+    public static final int IRQ_TIMEOUT = 1 << 10;
+    public static final int IRQ_COMMAND_ERROR = 1 << 22;
+
+    /**
+     * The radio counts time in ticks of its 32.768 kHz clock, so a timeout in
+     * milliseconds is scaled by this. 1 ms is 32.768 ticks.
+     */
+    private static final double TICKS_PER_MS = 32.768;
+
+    /** How long a command may leave the radio busy before something is wrong. */
+    private static final Duration READY_TIMEOUT = Duration.ofSeconds(1);
+
+    private final Lr11xxIo io;
+
+    /** Remembered from configure(), because the amplifier belongs to the board. */
+    private BoardConfig board = BoardConfig.core1121();
+
+    /**
+     * 2 MHz, which is what this driver asks for unless told otherwise.
+     *
+     * <p>The vendor's demo uses 10 MHz. That is fine down a short ribbon to a HAT
+     * and marginal over jumper wires with no ground return beside each signal — and
+     * marginal SPI does not fail cleanly. It corrupts the odd byte into a plausible
+     * number, such as a version that reads 0x14 instead of 0x22. Two megahertz
+     * carries this radio's packets with time to spare.
+     */
+    public static final int DEFAULT_BAUD = 2_000_000;
+
+    /**
+     * The ordinary way in: name the wiring, get a radio.
+     *
+     * <p>This asks for the things only the person who wired the board can know, and
+     * sets everything that is the chip's business rather than theirs. All of it is
+     * required, because a constructor that cannot be called without the pin numbers
+     * is a better guarantee than any amount of checking afterwards.
+     *
+     * <pre>{@code
+     * try (Lr1121Driver radio = new Lr1121Driver(pi4j, 0, SpiChipSelect.CS_0, 22, 24, 23)) {
+     *     ...
+     * }
+     * }</pre>
+     *
+     * <p>What it sets for you, and why none of it belongs to the caller:
+     *
+     * <ul>
+     * <li><b>SPI mode 0.</b> The chip clocks on the rising edge with the clock
+     * idling low, and speaks no other mode.</li>
+     * <li><b>Reset high from the moment the line is claimed</b>, and left high on
+     * shutdown. Reset is active low, so an output that comes up at zero holds the
+     * radio in reset — after which it answers nothing, its busy line never falls,
+     * and every symptom points at the wiring.</li>
+     * <li><b>No debounce on either input.</b> Pi4J defaults inputs to 10 000 µs and
+     * passes that to the kernel, which then reports no edge at all for a shorter
+     * pulse. This radio raises its interrupt line only until the driver clears the
+     * interrupt — three short reads — so the default costs every reception,
+     * silently, and looks exactly like a missing antenna.</li>
+     * <li><b>No pull resistor.</b> Both lines are driven by the chip.</li>
+     * </ul>
+     *
+     * @param pi4j the caller's context. The radio creates its bus and lines from it
+     *        and closes them again on {@link #close()}, and does not touch the
+     *        context itself
+     * @param spiBus the SPI bus, 0 on a Raspberry Pi's header
+     * @param chipSelect the controller's own chip select, which the radio's NSS pin
+     *        goes to — {@code CS_0} is CE0. The kernel drives it around each
+     *        transfer, so it is not one of the pins below
+     * @param resetPin the radio's NRST pin, as a BCM number
+     * @param busyPin the radio's BUSY pin, as a BCM number
+     * @param interruptPin the radio's DIO9 pin, as a BCM number
+     */
+    public Lr1121Driver(Context pi4j, int spiBus, SpiChipSelect chipSelect,
+                        int resetPin, int busyPin, int interruptPin) {
+        this(pi4j, spiBus, chipSelect, resetPin, busyPin, interruptPin, DEFAULT_BAUD);
+    }
+
+    /**
+     * The same, with a bus speed of your own.
+     *
+     * @param baud hertz. See {@link #DEFAULT_BAUD} for why faster is opt-in
+     */
+    public Lr1121Driver(Context pi4j, int spiBus, SpiChipSelect chipSelect,
+                        int resetPin, int busyPin, int interruptPin, int baud) {
+        this(new Pi4jLr11xxIo(
+                pi4j.create(SpiConfigBuilder.newInstance(pi4j)
+                        .id("lr11xx-spi")
+                        .bus(spiBus)
+                        .chipSelect(chipSelect)
+                        .mode(SpiMode.MODE_0)
+                        .baud(baud)
+                        .build()),
+                pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j)
+                        .id("lr11xx-reset")
+                        .bcm(resetPin)
+                        .initial(DigitalState.HIGH)
+                        .shutdown(DigitalState.HIGH)
+                        .build()),
+                input(pi4j, "lr11xx-busy", busyPin),
+                input(pi4j, "lr11xx-irq", interruptPin),
+                true));
+    }
+
+    private static DigitalInput input(Context pi4j, String id, int bcm) {
+        return pi4j.create(DigitalInputConfigBuilder.newInstance(pi4j)
+                .id(id)
+                .bcm(bcm)
+                .pull(PullResistance.OFF)
+                .debounce(0L)
+                .build());
+    }
+
+    /**
+     * The ordinary way in: the SPI bus the radio is on, and the three lines that
+     * are not part of it.
+     *
+     * <p>Chip select is <b>not</b> among them. The radio's NSS pin goes to the SPI
+     * controller's own chip select — CE0 on a Raspberry Pi — and the kernel drives
+     * it around each transfer.
+     *
+     * <p>The reset line must be created high. It is active low, so an output that
+     * comes up at zero holds the radio in reset, after which it answers nothing and
+     * every symptom points at the wiring.
+     *
+     * <p>The two inputs <b>must</b> be created with {@code .debounce(0L)}, and this
+     * constructor refuses them otherwise. Pi4J debounces by ten milliseconds unless
+     * told not to, and passes that to the kernel — which then reports no edge at all
+     * for a pulse shorter than the window. This radio's pulses are far shorter, so
+     * the default costs every reception and looks exactly like a missing antenna.
+     *
+     * <pre>{@code
+     * Spi spi = pi4j.create(SpiConfigBuilder.newInstance(pi4j)
+     *         .bus(0).chipSelect(SpiChipSelect.CS_0).mode(SpiMode.MODE_0).baud(2_000_000));
+     * DigitalOutput reset = pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j)
+     *         .bcm(22).initial(DigitalState.HIGH).shutdown(DigitalState.HIGH));
+     * DigitalInput busy = pi4j.create(DigitalInputConfigBuilder.newInstance(pi4j)
+     *         .bcm(24).debounce(0L));
+     * DigitalInput irq = pi4j.create(DigitalInputConfigBuilder.newInstance(pi4j)
+     *         .bcm(23).debounce(0L));
+     *
+     * try (Lr1121Driver radio = new Lr1121Driver(spi, reset, busy, irq)) {
+     *     ...
+     * }
+     * }</pre>
+     *
+     * @param spi the bus, in mode 0. 10 MHz is what the vendor's demo uses; 2 MHz
+     *        is a better choice over jumper wires, where a marginal bus corrupts
+     *        the odd byte into a plausible-looking value rather than failing
+     * @param reset the radio's NRST pin, active low
+     * @param busy the radio's BUSY pin
+     * @param interrupt the radio's DIO9 pin
+     */
+    public Lr1121Driver(Spi spi, DigitalOutput reset, DigitalInput busy, DigitalInput interrupt) {
+        this(new Pi4jLr11xxIo(spi, reset, busy, interrupt));
+    }
+
+    /**
+     * For a radio reached some other way — a USB adapter, or a recording in a
+     * test. {@link Lr11xxIo} is the whole of what this driver needs from the wires.
+     */
+    public Lr1121Driver(Lr11xxIo io) {
+        this.io = io;
+    }
+
+    /**
+     * The chip's own answer to "what are you", which is the first thing to ask:
+     * a wiring mistake produces zeros or 0xFF here rather than an error anywhere
+     * else.
+     *
+     * @return hardware, use case type and firmware version
+     */
+    public Version version() {
+        byte[] answer = query(GET_VERSION, 4);
+        return new Version(answer[0] & 0xFF, answer[1] & 0xFF,
+                ((answer[2] & 0xFF) << 8) | (answer[3] & 0xFF));
+    }
+
+    /** Hardware revision, device type, and firmware version. */
+    public record Version(int hardware, int useCase, int firmware) {
+
+        /** What an LR1121 calls itself. An LR1110 is 0x01, an LR1120 is 0x02. */
+        public static final int LR1121 = 0x03;
+
+        /**
+         * What the chip calls itself while the bootloader is running, before it
+         * has handed over to the application firmware.
+         */
+        public static final int BOOTLOADER = 0xDF;
+
+        public boolean isBootloader() {
+            return useCase == BOOTLOADER;
+        }
+
+        @Override
+        public String toString() {
+            String what = switch (useCase) {
+                case LR1121 -> "LR1121";
+                case BOOTLOADER -> "bootloader";
+                default -> "unknown device";
+            };
+            return "hardware 0x%02X, type 0x%02X (%s), firmware 0x%04X"
+                    .formatted(hardware, useCase, what, firmware);
+        }
+    }
+
+    /**
+     * Brings the radio up: reset, the board's own oscillator and antenna switch,
+     * then a calibration.
+     *
+     * <p>The order matters and is not obvious. The oscillator has to be configured
+     * before calibrating, because the calibration measures against it — calibrate
+     * first and the radio is trimmed for a clock it is not going to use.
+     */
+    public void configure(BoardConfig board) {
+        this.board = board;
+        awaitApplicationFirmware();
+        standby();
+
+        if (board.hasTcxo()) {
+            command(SET_TCXO_MODE,
+                    board.tcxoVoltage(),
+                    (board.tcxoStartupTicks() >> 16) & 0xFF,
+                    (board.tcxoStartupTicks() >> 8) & 0xFF,
+                    board.tcxoStartupTicks() & 0xFF);
+        }
+
+        command(SET_DIO_AS_RF_SWITCH,
+                board.rfSwitchEnable(), board.rfSwitchStandby(), board.rfSwitchRx(),
+                board.rfSwitchTx(), board.rfSwitchTxHp(), board.rfSwitchTxHf(),
+                0 /* gnss */, 0 /* wifi */);
+
+        // The low frequency clock, with the "wait until the 32 kHz is ready" bit.
+        command(CFG_LFCLK, LFCLK_XTAL | (1 << 2));
+
+        clearErrors();
+        command(CALIBRATE, CALIBRATE_ALL);
+    }
+
+    /**
+     * The modulation and the channel. Both ends of a link must call this with the
+     * same values; there is nothing in LoRa that would notice if they did not.
+     */
+    public void configureLora(long frequencyHz, LoraSettings settings) {
+        command(SET_PACKET_TYPE, PACKET_TYPE_LORA);
+        command(SET_RF_FREQUENCY,
+                (int) ((frequencyHz >> 24) & 0xFF), (int) ((frequencyHz >> 16) & 0xFF),
+                (int) ((frequencyHz >> 8) & 0xFF), (int) (frequencyHz & 0xFF));
+        calibrateImage(frequencyHz);
+        command(SET_MODULATION_PARAMS,
+                settings.spreadingFactor(), settings.bandwidth(), settings.codingRate(),
+                settings.lowDataRateOptimisation() ? 1 : 0);
+        command(SET_LORA_SYNC_WORD, settings.syncWord());
+    }
+
+    /**
+     * Waits for a packet.
+     *
+     * @param settings the same settings the sender used
+     * @param timeout how long to listen
+     * @return the packet, or empty if nothing arrived in time or what arrived was
+     *         corrupt. A CRC error is reported as nothing rather than as bytes,
+     *         which is the only safe reading of a packet the radio knows is wrong
+     */
+    public Optional<ReceivedPacket> receive(LoraSettings settings, Duration timeout) {
+        // 255: the largest a LoRa packet can be, since we do not know yet.
+        packetParams(settings, 255);
+        command(SET_DIO_IRQ_PARAMS, irqMask(IRQ_RX_DONE | IRQ_CRC_ERROR | IRQ_HEADER_ERROR | IRQ_TIMEOUT));
+        clearIrq(0xFFFFFFFF);
+
+        /*
+           Zero means "listen until told otherwise" rather than "do not listen".
+           The waiting is done here, so that the caller can interrupt a receiver
+           that would otherwise sit in the radio's own timeout.
+        */
+        command(SET_RX, 0, 0, 0);
+
+        int irq = awaitReception(timeout);
+        clearIrq(irq);
+
+        if (irq == 0) {
+            standby();
+            return Optional.empty();
+        }
+
+        if ((irq & IRQ_RX_DONE) == 0 || (irq & (IRQ_CRC_ERROR | IRQ_HEADER_ERROR)) != 0) {
+            standby();
+            return Optional.empty();
+        }
+
+        byte[] status = query(GET_RX_BUFFER_STATUS, 2);
+        int length = status[0] & 0xFF;
+        int start = status[1] & 0xFF;
+
+        byte[] payload = query(READ_BUFFER8, length, start, length);
+
+        byte[] packetStatus = query(GET_PACKET_STATUS, 3);
+        int rssi = -(packetStatus[0] & 0xFF) / 2;
+        double snr = ((byte) packetStatus[1]) / 4.0;
+
+        standby();
+        return Optional.of(new ReceivedPacket(payload, rssi, snr));
+    }
+
+    /**
+     * Sends a packet and waits for the radio to say it has gone.
+     *
+     * @param powerDbm the output power. The high power path reaches 22 dBm; what
+     *        is legal depends on where you are, and in EU868 it is 14 dBm ERP on
+     *        most channels
+     */
+    public void transmit(byte[] payload, LoraSettings settings, int powerDbm, Duration timeout) {
+        if (payload.length > 255) {
+            throw new IllegalArgumentException(
+                    "A LoRa packet holds 255 bytes, was given " + payload.length);
+        }
+
+        writeBuffer(payload);
+        packetParams(settings, payload.length);
+        transmitPower(powerDbm);
+        command(SET_DIO_IRQ_PARAMS, irqMask(IRQ_TX_DONE | IRQ_TIMEOUT));
+        clearIrq(0xFFFFFFFF);
+
+        command(SET_TX, 0, 0, 0);
+
+        if (!io.awaitInterrupt(timeout)) {
+            standby();
+            throw new IllegalStateException("The radio did not report the packet as sent within " + timeout);
+        }
+
+        int irq = irqStatus();
+        clearIrq(irq);
+        standby();
+
+        if ((irq & IRQ_TX_DONE) == 0) {
+            throw new IllegalStateException("Transmission ended without a done interrupt, IRQ 0x%08X"
+                    .formatted(irq));
+        }
+    }
+
+    /**
+     * Resets the radio and waits for it to hand over from its bootloader.
+     *
+     * <p>An LR11xx starts in a bootloader that checks the flash and then jumps to
+     * the application firmware. Asked for its version during that window it
+     * answers honestly — as the bootloader, device 0xDF — and a bootloader
+     * accepts firmware updates and nothing else. Every ordinary command then
+     * fails, which looks like a broken radio rather than an impatient host.
+     *
+     * <p>So the reset is followed by asking until the answer changes, and by
+     * resetting again if it does not. A module whose firmware really is missing
+     * never changes its answer, and says so.
+     */
+    private void awaitApplicationFirmware() {
+        for (int attempt = 0; attempt < BOOT_ATTEMPTS; attempt++) {
+            io.reset();
+
+            long deadline = System.nanoTime() + BOOT_TIMEOUT.toNanos();
+            while (System.nanoTime() < deadline) {
+                if (!version().isBootloader()) {
+                    return;
+                }
+                sleep(BOOT_POLL);
+            }
+        }
+        throw new IllegalStateException(
+                "The radio is still in its bootloader after " + BOOT_ATTEMPTS
+                + " resets, so it has no working firmware to hand over to."
+                + " It will accept a firmware update and nothing else.");
+    }
+
+    private static final int BOOT_ATTEMPTS = 3;
+    private static final Duration BOOT_TIMEOUT = Duration.ofMillis(500);
+    private static final Duration BOOT_POLL = Duration.ofMillis(20);
+
+    private static void sleep(Duration duration) {
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for the radio to boot", e);
+        }
+    }
+
+    /**
+     * Calibrates the image rejection for the band actually in use.
+     *
+     * <p>This is the one calibration that cannot be done in advance, because it
+     * is about a band rather than about the chip: {@code Calibrate} trims the
+     * image filter for wherever the radio was last pointed, which before a
+     * frequency is set is nowhere useful. The cost of skipping it is not an error
+     * at the time — it is a receiver that works and hears less than it should.
+     *
+     * <p>The band edges are given in units of 4 MHz, rounded outwards, which for
+     * 868 MHz gives the 0xD7 and 0xDB that the vendor's own driver uses for
+     * 863–870.
+     */
+    public void calibrateImage(long frequencyHz) {
+        double megahertz = frequencyHz / 1_000_000.0;
+        int lower = (int) Math.floor((megahertz - BAND_MARGIN_MHZ) / 4.0);
+        int upper = (int) Math.ceil((megahertz + BAND_MARGIN_MHZ) / 4.0);
+        command(CALIBRATE_IMAGE, lower & 0xFF, upper & 0xFF);
+    }
+
+    /**
+     * How far either side of the carrier the image calibration covers. Wide
+     * enough that one calibration serves a whole ISM band rather than a single
+     * channel, which is what the vendor's own values do.
+     */
+    private static final double BAND_MARGIN_MHZ = 8.0;
+
+    /**
+     * Waits for the radio to finish a reception, and returns the flags saying how
+     * it went — or zero if the time ran out.
+     *
+     * <p>The interrupt line is used as a hint, not as the truth. The flags in the
+     * chip are what actually says a packet arrived, and asking for them costs one
+     * short SPI read; depending on a single wire to learn something the radio
+     * will tell you anyway is a way to have a receiver that is silent for a
+     * reason nothing reports.
+     *
+     * <p>So this waits on the line in short slices and reads the flags after each
+     * one. A working interrupt makes it return promptly; a disconnected one costs
+     * a fraction of a second and nothing else.
+     */
+    private int awaitReception(Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        int interesting = IRQ_RX_DONE | IRQ_CRC_ERROR | IRQ_HEADER_ERROR | IRQ_TIMEOUT;
+
+        while (System.nanoTime() < deadline) {
+            io.awaitInterrupt(POLL_SLICE);
+
+            int irq = irqStatus();
+            if ((irq & interesting) != 0) {
+                return irq;
+            }
+        }
+        return 0;
+    }
+
+    /**
+     * How long each wait on the interrupt line lasts before the flags are read
+     * anyway. Short enough that a dead line costs little, long enough that a live
+     * one does the waiting.
+     */
+    private static final Duration POLL_SLICE = Duration.ofMillis(200);
+
+    /** Puts the radio in standby on its internal oscillator. */
+    public void standby() {
+        command(SET_STANDBY, STANDBY_RC);
+    }
+
+    /**
+     * The errors the radio has accumulated. Worth reading after configuring: a
+     * failed image calibration shows up here and nowhere else, and it costs
+     * sensitivity rather than producing an error.
+     */
+    public int errors() {
+        byte[] answer = query(GET_ERRORS, 2);
+        return ((answer[0] & 0xFF) << 8) | (answer[1] & 0xFF);
+    }
+
+    public void clearErrors() {
+        command(CLEAR_ERRORS);
+    }
+
+    /**
+     * The interrupt flags, read the way this one command has to be read.
+     *
+     * <p>GetStatus is not a command with a response — it is a <b>direct read</b>.
+     * Clocking bytes out without sending anything first returns the two status
+     * bytes and then the interrupt word, and there is no leading status byte to
+     * discard because the first byte <em>is</em> it.
+     *
+     * <p>Treating it like an ordinary command shifts the whole word one byte
+     * left, which puts RX_DONE at 0x0800 instead of 0x08. Nothing errors: the
+     * interrupt fires, the flags are read, and every packet is quietly dropped as
+     * "not a reception". That cost an evening.
+     */
+    public int irqStatus() {
+        byte[] status = directRead(6);
+        return ((status[2] & 0xFF) << 24) | ((status[3] & 0xFF) << 16)
+                | ((status[4] & 0xFF) << 8) | (status[5] & 0xFF);
+    }
+
+    public void clearIrq(int mask) {
+        command(CLEAR_IRQ, (mask >>> 24) & 0xFF, (mask >>> 16) & 0xFF,
+                (mask >>> 8) & 0xFF, mask & 0xFF);
+    }
+
+    @Override
+    public void close() {
+        io.close();
+    }
+
+    // ------------------------------------------------------------------
+    // The two shapes every command has
+    // ------------------------------------------------------------------
+
+    /** A command that only tells the radio something. */
+    private void command(int opcode, int... arguments) {
+        byte[] bytes = new byte[2 + arguments.length];
+        bytes[0] = (byte) (opcode >> 8);
+        bytes[1] = (byte) opcode;
+        for (int i = 0; i < arguments.length; i++) {
+            bytes[2 + i] = (byte) arguments[i];
+        }
+        io.awaitReady(READY_TIMEOUT);
+        io.writeBytes(bytes);
+    }
+
+    /**
+     * A command that answers. Two transactions with a wait between them, and the
+     * first byte clocked back is the radio's status rather than the answer — it is
+     * dropped here so that no caller has to remember it.
+     */
+    private byte[] query(int opcode, int responseLength, int... arguments) {
+        command(opcode, arguments);
+
+        io.awaitReady(READY_TIMEOUT);
+        byte[] raw = new byte[responseLength + 1];
+        io.readBytes(raw);
+
+        byte[] response = new byte[responseLength];
+        System.arraycopy(raw, 1, response, 0, responseLength);
+        return response;
+    }
+
+    /**
+     * Bytes clocked out with no command sent first, which is how the chip reports
+     * its own state. See {@link #irqStatus()} for why this is not the same as a
+     * command that answers.
+     */
+    private byte[] directRead(int length) {
+        io.awaitReady(READY_TIMEOUT);
+        byte[] bytes = new byte[length];
+        io.readBytes(bytes);
+        return bytes;
+    }
+
+    private void packetParams(LoraSettings settings, int payloadLength) {
+        command(SET_PACKET_PARAMS,
+                (settings.preambleSymbols() >> 8) & 0xFF, settings.preambleSymbols() & 0xFF,
+                settings.explicitHeader() ? 0x00 : 0x01,
+                payloadLength,
+                settings.crc() ? 0x01 : 0x00,
+                settings.invertIq() ? 0x01 : 0x00);
+    }
+
+    private void writeBuffer(byte[] payload) {
+        int[] arguments = new int[payload.length];
+        for (int i = 0; i < payload.length; i++) {
+            arguments[i] = payload[i] & 0xFF;
+        }
+        command(WRITE_BUFFER8, arguments);
+    }
+
+    /**
+     * The power amplifier and the ramp.
+     *
+     * <p>Which amplifier to use is a property of the board, not of the power
+     * asked for. A module routes one of the chip's outputs to its antenna and
+     * leaves the others unconnected, so choosing by power — the low power path
+     * below 14 dBm, the high power one above — transmits into a pin that goes
+     * nowhere for half of the range.
+     *
+     * <p>That is what this did, and it cost most of an evening: the Core1121
+     * wires the high power output, the vendor's table selects it at every level
+     * from -9 to +22 dBm, and asking for 14 dBm here selected the other one.
+     * Nothing reports it. The radio transmits happily and the far end hears the
+     * leakage.
+     *
+     * <p>The byte order was wrong as well — it is select, supply, duty cycle,
+     * size — so the duty cycle was being set from the supply's value.
+     */
+    private void transmitPower(int powerDbm) {
+        command(SET_PA_CONFIG,
+                board.amplifier(),
+                board.amplifierSupply(),
+                board.amplifierDutyCycle(),
+                board.amplifierSize());
+        command(SET_TX_PARAMS, powerDbm & 0xFF, 0x04 /* 48 µs ramp */);
+    }
+
+    /** The 32 bit interrupt mask, sent for both DIO lines. */
+    private static int[] irqMask(int mask) {
+        return new int[] {
+                (mask >>> 24) & 0xFF, (mask >>> 16) & 0xFF, (mask >>> 8) & 0xFF, mask & 0xFF,
+                0, 0, 0, 0,
+        };
+    }
+
+    static int millisecondsToTicks(long milliseconds) {
+        return (int) Math.round(milliseconds * TICKS_PER_MS);
+    }
+
+    // ------------------------------------------------------------------
+    // Value types, nested so client code can say Lr1121Driver.LoraSettings
+    // ------------------------------------------------------------------
+
+    /**
+     * The handful of values that belong to the board rather than to the radio.
+     *
+     * <p>These are the ones a datasheet cannot tell you, because they describe how
+     * the chip was wired: what supplies the crystal oscillator, and which DIO pins
+     * drive the antenna switch. Getting them wrong produces a radio that answers
+     * every command correctly and hears nothing, which is the worst failure a first
+     * link can have.
+     *
+     * @param tcxoVoltage one of the {@code TCXO_} constants, or {@link #NO_TCXO}
+     * @param tcxoStartupTicks how long to let the oscillator settle, in units of
+     *        30.52 µs
+     * @param rfSwitchEnable which DIO pins are used as the antenna switch at all
+     * @param rfSwitchStandby their levels in standby
+     * @param rfSwitchRx their levels while receiving
+     * @param rfSwitchTx their levels while transmitting
+     * @param rfSwitchTxHp the same for the high power path
+     * @param rfSwitchTxHf the same for the high frequency (2.4 GHz) path
+     */
+    public record BoardConfig(int tcxoVoltage, int tcxoStartupTicks,
+                              int rfSwitchEnable, int rfSwitchStandby, int rfSwitchRx,
+                              int rfSwitchTx, int rfSwitchTxHp, int rfSwitchTxHf,
+                              int amplifier, int amplifierSupply,
+                              int amplifierDutyCycle, int amplifierSize) {
+
+        public static final int NO_TCXO = -1;
+
+        public static final int TCXO_1_6V = 0x00;
+        public static final int TCXO_1_7V = 0x01;
+        public static final int TCXO_1_8V = 0x02;
+        public static final int TCXO_2_2V = 0x03;
+        public static final int TCXO_2_4V = 0x04;
+        public static final int TCXO_2_7V = 0x05;
+        public static final int TCXO_3_0V = 0x06;
+        public static final int TCXO_3_3V = 0x07;
+
+        /** Which power amplifier the board's antenna is actually wired to. */
+        public static final int PA_LOW_POWER = 0x00;
+        public static final int PA_HIGH_POWER = 0x01;
+        public static final int PA_HIGH_FREQUENCY = 0x02;
+
+        public static final int PA_SUPPLY_REGULATOR = 0x00;
+        public static final int PA_SUPPLY_BATTERY = 0x01;
+
+        public static final int RFSW0 = 1 << 0;
+        public static final int RFSW1 = 1 << 1;
+        public static final int RFSW2 = 1 << 2;
+        public static final int RFSW3 = 1 << 3;
+        public static final int RFSW4 = 1 << 4;
+
+        /**
+         * The Waveshare Core1121, both the HF and the LF variant.
+         *
+         * <p>Taken from the vendor's own demo rather than worked out: a 3.0 V TCXO
+         * with a 300 tick settling time, RFSW0 for receive and RFSW1 for transmit,
+         * and no high frequency path in the switch — the 2.4 GHz output is a separate
+         * connector.
+         *
+         * <p>The pin-by-pin wiring this was tested with is in the javadoc of
+         * {@code Lr11xxLinkCheck}, alongside the hardware checks that use it.
+         *
+         * @see <a href="https://www.waveshare.com/wiki/Core1121-XF">Core1121-XF</a>
+         */
+        public static BoardConfig core1121() {
+            return new BoardConfig(TCXO_3_0V, 300,
+                    RFSW0 | RFSW1, 0, RFSW0, RFSW1, RFSW1, 0,
+                    /*
+                       The high power amplifier, from the battery rail, at every
+                       power level — which is what the vendor's own table does for
+                       all of -9 to +22 dBm without variation.
+                
+                       That uniformity is the tell. A board that never uses its low
+                       power amplifier is a board whose low power output goes
+                       nowhere, and selecting it transmits into an unconnected pin.
+                    */
+                    PA_HIGH_POWER, PA_SUPPLY_BATTERY, 0x04, 0x07);
+        }
+
+        public boolean hasTcxo() {
+            return tcxoVoltage != NO_TCXO;
+        }
+    }
+
+    /**
+     * The modulation, which both ends of a link have to agree on exactly. One
+     * mismatched field and the receiver hears nothing at all — there is no
+     * negotiation and no error, which is what makes a link that will not come up so
+     * frustrating to debug.
+     *
+     * @param spreadingFactor 5 to 12. Higher reaches further and takes longer: 16
+     *        bytes is about 165 ms at SF9 and 1.3 s at SF12
+     * @param bandwidth one of the {@code BW_} constants
+     * @param codingRate one of the {@code CR_} constants
+     * @param syncWord 0x12 for private networks, 0x34 for public LoRaWAN ones
+     * @param preambleSymbols 8 is the usual choice and what LoRaWAN uses
+     * @param explicitHeader whether the length travels in the packet. With an
+     *        implicit header both ends must agree the length in advance
+     * @param crc whether the radio appends and checks a CRC, which is how a corrupt
+     *        packet is dropped rather than delivered as noise
+     * @param invertIq LoRaWAN inverts it downlink so that gateways do not hear each
+     *        other. For a plain link, false at both ends
+     */
+    public record LoraSettings(int spreadingFactor, int bandwidth, int codingRate, int syncWord,
+                               int preambleSymbols, boolean explicitHeader, boolean crc,
+                               boolean invertIq) {
+
+        public static final int BW_125_KHZ = 0x04;
+        public static final int BW_250_KHZ = 0x05;
+        public static final int BW_500_KHZ = 0x06;
+
+        public static final int CR_4_5 = 0x01;
+        public static final int CR_4_6 = 0x02;
+        public static final int CR_4_7 = 0x03;
+        public static final int CR_4_8 = 0x04;
+
+        /** The usual sync word for a link that is not part of a LoRaWAN network. */
+        public static final int SYNC_WORD_PRIVATE = 0x12;
+        public static final int SYNC_WORD_PUBLIC = 0x34;
+
+        public LoraSettings {
+            if (spreadingFactor < 5 || spreadingFactor > 12) {
+                throw new IllegalArgumentException(
+                        "Spreading factor is 5 to 12, was " + spreadingFactor);
+            }
+            if (preambleSymbols < 1 || preambleSymbols > 0xFFFF) {
+                throw new IllegalArgumentException(
+                        "Preamble length does not fit in the packet, was " + preambleSymbols);
+            }
+        }
+
+        /**
+         * A sensible starting point for a link across a house or a garden: SF9 at
+         * 125 kHz, which sends a short packet in about a sixth of a second.
+         */
+        public static LoraSettings defaults() {
+            return new LoraSettings(9, BW_125_KHZ, CR_4_5, SYNC_WORD_PRIVATE, 8, true, true, false);
+        }
+
+        /*
+           A wither per field anyone realistically varies, so that a link can be
+           described by naming what differs from the defaults. The canonical
+           constructor takes eight arguments, two of which are bare booleans next to
+           each other — write those two the wrong way round and the radio hears
+           nothing, with no error to say so. Nobody should have to reach for it.
+        */
+
+        public LoraSettings withSpreadingFactor(int spreadingFactor) {
+            return new LoraSettings(spreadingFactor, bandwidth, codingRate, syncWord,
+                    preambleSymbols, explicitHeader, crc, invertIq);
+        }
+
+        /** One of the {@code BW_} constants. */
+        public LoraSettings withBandwidth(int bandwidth) {
+            return new LoraSettings(spreadingFactor, bandwidth, codingRate, syncWord,
+                    preambleSymbols, explicitHeader, crc, invertIq);
+        }
+
+        /** One of the {@code CR_} constants. */
+        public LoraSettings withCodingRate(int codingRate) {
+            return new LoraSettings(spreadingFactor, bandwidth, codingRate, syncWord,
+                    preambleSymbols, explicitHeader, crc, invertIq);
+        }
+
+        /** {@link #SYNC_WORD_PRIVATE} or {@link #SYNC_WORD_PUBLIC}. */
+        public LoraSettings withSyncWord(int syncWord) {
+            return new LoraSettings(spreadingFactor, bandwidth, codingRate, syncWord,
+                    preambleSymbols, explicitHeader, crc, invertIq);
+        }
+
+        /**
+         * Whether the radio appends and checks a CRC. Both ends must agree, and a
+         * receiver expecting one hears a packet without it as a packet that failed
+         * its check — which is indistinguishable from no packet at all.
+         */
+        public LoraSettings withCrc(boolean crc) {
+            return new LoraSettings(spreadingFactor, bandwidth, codingRate, syncWord,
+                    preambleSymbols, explicitHeader, crc, invertIq);
+        }
+
+        /**
+         * Whether the low data rate optimisation has to be on. It is required when a
+         * symbol lasts longer than 16 ms, which is the combination of a high
+         * spreading factor and a narrow bandwidth — and both ends must make the same
+         * decision, so it is derived rather than configured.
+         */
+        public boolean lowDataRateOptimisation() {
+            double bandwidthHz = switch (bandwidth) {
+                case BW_125_KHZ -> 125_000.0;
+                case BW_250_KHZ -> 250_000.0;
+                case BW_500_KHZ -> 500_000.0;
+                default -> throw new IllegalStateException("Unknown bandwidth " + bandwidth);
+            };
+            return (Math.pow(2, spreadingFactor) / bandwidthHz) > 0.016;
+        }
+    }
+
+    /**
+     * A packet that arrived, with the two numbers that say how well.
+     *
+     * @param payload the bytes, exactly as the sender wrote them
+     * @param rssiDbm signal strength; a LoRa link is workable well below -120
+     * @param snrDb signal to noise; LoRa decodes below zero, which is the whole
+     *        point of it — down to about -20 at SF12
+     */
+    public record ReceivedPacket(byte[] payload, int rssiDbm, double snrDb) {
+
+        public int length() {
+            return payload.length;
+        }
+
+        @Override
+        public String toString() {
+            StringBuilder hex = new StringBuilder(payload.length * 2);
+            for (byte b : payload) {
+                hex.append("%02X".formatted(b));
+            }
+            return "%d bytes, RSSI %d dBm, SNR %.1f dB: %s"
+                    .formatted(payload.length, rssiDbm, snrDb, hex);
+        }
+    }
+}

--- a/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121Driver.java
+++ b/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121Driver.java
@@ -5,12 +5,14 @@ import java.time.Duration;
 import java.util.Optional;
 
 import com.pi4j.context.Context;
+import com.pi4j.io.ListenableOnOffRead;
+import com.pi4j.io.OnOffRead;
+import com.pi4j.io.OnOffWrite;
 import com.pi4j.io.gpio.digital.DigitalInput;
 import com.pi4j.io.gpio.digital.DigitalInputConfigBuilder;
 import com.pi4j.io.gpio.digital.DigitalOutput;
 import com.pi4j.io.gpio.digital.DigitalOutputConfigBuilder;
 import com.pi4j.io.gpio.digital.DigitalState;
-import com.pi4j.io.gpio.digital.PullResistance;
 import com.pi4j.io.spi.Spi;
 import com.pi4j.io.spi.SpiChipSelect;
 import com.pi4j.io.spi.SpiConfigBuilder;
@@ -99,7 +101,15 @@ public class Lr1121Driver implements Closeable {
 
     private final Lr11xxIo io;
 
-    /** Remembered from configure(), because the amplifier belongs to the board. */
+    /**
+     * Remembered from {@link #configure(BoardConfig)}, because the amplifier belongs
+     * to the board rather than to the power asked for.
+     *
+     * <p>Until then it is the Core1121's. That default only matters to a radio
+     * transmitting without ever having been configured — one whose oscillator and
+     * antenna switch have not been set up either, so the amplifier is the least of
+     * what is wrong with it.
+     */
     private BoardConfig board = BoardConfig.core1121();
 
     /**
@@ -117,9 +127,7 @@ public class Lr1121Driver implements Closeable {
      * The ordinary way in: name the wiring, get a radio.
      *
      * <p>This asks for the things only the person who wired the board can know, and
-     * sets everything that is the chip's business rather than theirs. All of it is
-     * required, because a constructor that cannot be called without the pin numbers
-     * is a better guarantee than any amount of checking afterwards.
+     * sets everything that is the chip's business rather than theirs.
      *
      * <pre>{@code
      * try (Lr1121Driver radio = new Lr1121Driver(pi4j, 0, SpiChipSelect.CS_0, 22, 24, 23)) {
@@ -127,7 +135,7 @@ public class Lr1121Driver implements Closeable {
      * }
      * }</pre>
      *
-     * <p>What it sets for you, and why none of it belongs to the caller:
+     * <p>What it sets for you:
      *
      * <ul>
      * <li><b>SPI mode 0.</b> The chip clocks on the rising edge with the clock
@@ -143,6 +151,9 @@ public class Lr1121Driver implements Closeable {
      * silently, and looks exactly like a missing antenna.</li>
      * <li><b>No pull resistor.</b> Both lines are driven by the chip.</li>
      * </ul>
+     *
+     * <p>The bus and the lines are registered under ids that carry the wiring —
+     * {@code lr11xx-busy-24} and so on — so several radios can share one context.
      *
      * @param pi4j the caller's context. The radio creates its bus and lines from it
      *        and closes them again on {@link #close()}, and does not touch the
@@ -169,35 +180,36 @@ public class Lr1121Driver implements Closeable {
                         int resetPin, int busyPin, int interruptPin, int baud) {
         this(new Pi4jLr11xxIo(
                 pi4j.create(SpiConfigBuilder.newInstance(pi4j)
-                        .id("lr11xx-spi")
+                        .id("lr11xx-spi-" + spiBus + "-" + chipSelect.getChipSelect())
                         .bus(spiBus)
                         .chipSelect(chipSelect)
                         .mode(SpiMode.MODE_0)
                         .baud(baud)
                         .build()),
                 pi4j.create(DigitalOutputConfigBuilder.newInstance(pi4j)
-                        .id("lr11xx-reset")
+                        .id("lr11xx-reset-" + resetPin)
                         .bcm(resetPin)
                         .initial(DigitalState.HIGH)
                         .shutdown(DigitalState.HIGH)
                         .build()),
-                input(pi4j, "lr11xx-busy", busyPin),
-                input(pi4j, "lr11xx-irq", interruptPin),
+                pi4j.create(DigitalInputConfigBuilder.newInstance(pi4j)
+                        .id("lr11xx-busy-" + busyPin)
+                        .bcm(busyPin)
+                        .debounce(0L)
+                        .build()),
+                pi4j.create(DigitalInputConfigBuilder.newInstance(pi4j)
+                        .id("lr11xx-irq-" + interruptPin)
+                        .bcm(interruptPin)
+                        .debounce(0L)
+                        .build()),
                 true));
     }
 
-    private static DigitalInput input(Context pi4j, String id, int bcm) {
-        return pi4j.create(DigitalInputConfigBuilder.newInstance(pi4j)
-                .id(id)
-                .bcm(bcm)
-                .pull(PullResistance.OFF)
-                .debounce(0L)
-                .build());
-    }
-
     /**
-     * The ordinary way in: the SPI bus the radio is on, and the three lines that
-     * are not part of it.
+     * The same radio on lines the caller already has: a {@link DigitalOutput} and
+     * {@link DigitalInput}s built as below, or an I/O expander's pins from
+     * {@link com.pi4j.drivers.io.expander.OutputExpander#getOutput} and
+     * {@link com.pi4j.drivers.io.expander.InputExpander#getInput}.
      *
      * <p>Chip select is <b>not</b> among them. The radio's NSS pin goes to the SPI
      * controller's own chip select — CE0 on a Raspberry Pi — and the kernel drives
@@ -207,11 +219,12 @@ public class Lr1121Driver implements Closeable {
      * comes up at zero holds the radio in reset, after which it answers nothing and
      * every symptom points at the wiring.
      *
-     * <p>The two inputs <b>must</b> be created with {@code .debounce(0L)}, and this
-     * constructor refuses them otherwise. Pi4J debounces by ten milliseconds unless
-     * told not to, and passes that to the kernel — which then reports no edge at all
-     * for a pulse shorter than the window. This radio's pulses are far shorter, so
-     * the default costs every reception and looks exactly like a missing antenna.
+     * <p>A {@link DigitalInput} <b>must</b> be created with {@code .debounce(0L)},
+     * and this constructor refuses one that is not. Pi4J debounces by ten
+     * milliseconds unless told not to, and passes that to the kernel — which then
+     * reports no edge at all for a pulse shorter than the window. This radio's
+     * pulses are far shorter, so the default costs every reception and looks exactly
+     * like a missing antenna.
      *
      * <pre>{@code
      * Spi spi = pi4j.create(SpiConfigBuilder.newInstance(pi4j)
@@ -231,11 +244,13 @@ public class Lr1121Driver implements Closeable {
      * @param spi the bus, in mode 0. 10 MHz is what the vendor's demo uses; 2 MHz
      *        is a better choice over jumper wires, where a marginal bus corrupts
      *        the odd byte into a plausible-looking value rather than failing
-     * @param reset the radio's NRST pin, active low
+     * @param reset the radio's NRST pin, active low: off holds the radio in reset,
+     *        on runs it
      * @param busy the radio's BUSY pin
-     * @param interrupt the radio's DIO9 pin
+     * @param interrupt the radio's DIO9 pin, whose rising edge the driver waits on
      */
-    public Lr1121Driver(Spi spi, DigitalOutput reset, DigitalInput busy, DigitalInput interrupt) {
+    public Lr1121Driver(Spi spi, OnOffWrite<?> reset, OnOffRead<?> busy,
+                        ListenableOnOffRead<?> interrupt) {
         this(new Pi4jLr11xxIo(spi, reset, busy, interrupt));
     }
 
@@ -260,7 +275,14 @@ public class Lr1121Driver implements Closeable {
                 ((answer[2] & 0xFF) << 8) | (answer[3] & 0xFF));
     }
 
-    /** Hardware revision, device type, and firmware version. */
+    /**
+     * Hardware revision, device type, and firmware version.
+     *
+     * @param hardware the silicon revision
+     * @param useCase which chip this is, such as {@link #LR1121} — or
+     *        {@link #BOOTLOADER} before the firmware has taken over
+     * @param firmware the firmware version, as the chip reports it
+     */
     public record Version(int hardware, int useCase, int firmware) {
 
         /** What an LR1121 calls itself. An LR1110 is 0x01, an LR1120 is 0x02. */
@@ -295,6 +317,9 @@ public class Lr1121Driver implements Closeable {
      * <p>The order matters and is not obvious. The oscillator has to be configured
      * before calibrating, because the calibration measures against it — calibrate
      * first and the radio is trimmed for a clock it is not going to use.
+     *
+     * @param board how the chip was wired, which the driver also keeps: the power
+     *        amplifier every later {@link #transmit} uses belongs to the board
      */
     public void configure(BoardConfig board) {
         this.board = board;
@@ -324,6 +349,10 @@ public class Lr1121Driver implements Closeable {
     /**
      * The modulation and the channel. Both ends of a link must call this with the
      * same values; there is nothing in LoRa that would notice if they did not.
+     *
+     * @param frequencyHz the carrier, which also decides the band the image
+     *        rejection is calibrated for
+     * @param settings the modulation
      */
     public void configureLora(long frequencyHz, LoraSettings settings) {
         command(SET_PACKET_TYPE, PACKET_TYPE_LORA);
@@ -389,9 +418,12 @@ public class Lr1121Driver implements Closeable {
     /**
      * Sends a packet and waits for the radio to say it has gone.
      *
+     * @param payload up to 255 bytes, which is what a LoRa packet holds
+     * @param settings the modulation, which the receiver has to match exactly
      * @param powerDbm the output power. The high power path reaches 22 dBm; what
      *        is legal depends on where you are, and in EU868 it is 14 dBm ERP on
      *        most channels
+     * @param timeout how long to wait for the radio to report the packet as sent
      */
     public void transmit(byte[] payload, LoraSettings settings, int powerDbm, Duration timeout) {
         if (payload.length > 255) {
@@ -700,6 +732,15 @@ public class Lr1121Driver implements Closeable {
      * @param rfSwitchTx their levels while transmitting
      * @param rfSwitchTxHp the same for the high power path
      * @param rfSwitchTxHf the same for the high frequency (2.4 GHz) path
+     * @param amplifier which power amplifier the board's antenna is wired to, one of
+     *        the {@code PA_} constants. A property of the board, not of the power
+     *        asked for: the outputs the module leaves unconnected go nowhere at any
+     *        power
+     * @param amplifierSupply what feeds it, {@link #PA_SUPPLY_REGULATOR} or
+     *        {@link #PA_SUPPLY_BATTERY}
+     * @param amplifierDutyCycle the amplifier's duty cycle, as the vendor's table
+     *        for the board gives it
+     * @param amplifierSize the amplifier's size, from the same table
      */
     public record BoardConfig(int tcxoVoltage, int tcxoStartupTicks,
                               int rfSwitchEnable, int rfSwitchStandby, int rfSwitchRx,

--- a/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Lr11xxIo.java
+++ b/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Lr11xxIo.java
@@ -1,0 +1,52 @@
+package com.pi4j.drivers.radio.lora.lr11xx;
+
+import java.io.Closeable;
+import java.time.Duration;
+
+/**
+ * The wires: SPI bytes, a reset line, a busy line and an interrupt line.
+ *
+ * <p>Deliberately below the radio rather than beside it. Everything that makes an
+ * LR11xx an LR11xx — the opcodes, the two-transaction read, the status byte that
+ * arrives before every response — lives in {@link Lr1121Driver}, where it can be tested
+ * against a recording of the bytes. What is left here is what genuinely differs
+ * between a Raspberry Pi, a laptop with a USB adapter and a test: moving bytes.
+ *
+ * <p>This mirrors the six functions of Semtech's own HAL, which is the interface
+ * their C driver is written against. Keeping the same shape means a Java port of
+ * anything they publish translates rather than being redesigned.
+ */
+public interface Lr11xxIo extends Closeable {
+
+    /** One SPI transaction, MOSI only: chip select down, these bytes, chip select up. */
+    void writeBytes(byte[] bytes);
+
+    /**
+     * One SPI transaction, MISO only, filling the array. The radio answers a
+     * command in a transaction of its own, and the first byte of it is a status
+     * byte rather than data — {@link Lr1121Driver} accounts for that, not this.
+     */
+    void readBytes(byte[] into);
+
+    /**
+     * Blocks until the busy line says the radio is ready for a command.
+     *
+     * @throws IllegalStateException if it is still busy when the time runs out, which
+     *         means the radio is wedged or not there at all
+     */
+    void awaitReady(Duration timeout);
+
+    /** Pulses the reset line and waits for the radio to come back. */
+    void reset();
+
+    /**
+     * Waits for the interrupt line to go high.
+     *
+     * @return true if it did, false if the time ran out — which is not an error:
+     *         a receiver that hears nothing for a minute is the ordinary case
+     */
+    boolean awaitInterrupt(Duration timeout);
+
+    @Override
+    void close();
+}

--- a/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Pi4jLr11xxIo.java
+++ b/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Pi4jLr11xxIo.java
@@ -3,15 +3,24 @@ package com.pi4j.drivers.radio.lora.lr11xx;
 import java.time.Duration;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 
+import com.pi4j.io.IO;
+import com.pi4j.io.ListenableOnOffRead;
+import com.pi4j.io.OnOffRead;
+import com.pi4j.io.OnOffWrite;
 import com.pi4j.io.gpio.digital.DigitalInput;
-import com.pi4j.io.gpio.digital.DigitalOutput;
-import com.pi4j.io.gpio.digital.DigitalStateChangeListener;
 import com.pi4j.io.spi.Spi;
 
 /**
  * {@link Lr11xxIo} over Pi4J: SPI for the bytes, three digital lines for reset,
  * busy and the interrupt.
+ *
+ * <p>The three lines are held as {@link OnOffRead} / {@link OnOffWrite} rather than
+ * as {@code DigitalInput} and {@code DigitalOutput}, which is what a Raspberry Pi's
+ * own GPIO and an I/O expander have in common. Nothing here needs more than that:
+ * the reset line is driven, the busy line is read, and the interrupt line is
+ * listened to.
  *
  * <p>Package private on purpose. It is what {@link Lr1121Driver} builds when it is
  * handed Pi4J objects, and there is nothing here a caller needs to name.
@@ -25,16 +34,17 @@ class Pi4jLr11xxIo implements Lr11xxIo {
     private static final int BUSY_POLL_MICROS = 200;
 
     private final Spi spi;
-    private final DigitalOutput reset;
-    private final DigitalInput busy;
-    private final DigitalInput interrupt;
+    private final OnOffWrite<?> reset;
+    private final OnOffRead<?> busy;
+    private final ListenableOnOffRead<?> interrupt;
 
     /**
      * Whether the bus and the lines are ours to close.
      *
-     * <p>They are when {@code Lr1121Driver.on(pi4j)} created them, and they are not
-     * when a caller built them and handed them over: that caller may well have
-     * plans for the pins after the radio is done with them.
+     * <p>They are when the {@link Lr1121Driver} constructor that takes a Pi4J
+     * context created them, and they are not when a caller built them and handed
+     * them over: that caller may well have plans for the pins after the radio is
+     * done with them.
      */
     private final boolean ownsIo;
 
@@ -50,34 +60,35 @@ class Pi4jLr11xxIo implements Lr11xxIo {
      */
     private final Semaphore edges = new Semaphore(0);
 
-    private final DigitalStateChangeListener edgeListener = event -> {
+    private final Consumer<Boolean> edgeListener = on -> {
         /*
            Pi4J has no rising-edge-only request, so both edges arrive here and the
            falling one is dropped. The radio raises the interrupt line to signal and
            lowers it when the interrupt is cleared, so counting both would report
            twice as many receptions as there were.
         */
-        if (event.state().isHigh()) {
+        if (on) {
             edges.release();
         }
     };
 
-    Pi4jLr11xxIo(Spi spi, DigitalOutput reset, DigitalInput busy, DigitalInput interrupt) {
+    Pi4jLr11xxIo(Spi spi, OnOffWrite<?> reset, OnOffRead<?> busy,
+                 ListenableOnOffRead<?> interrupt) {
         this(spi, reset, busy, interrupt, false);
     }
 
-    Pi4jLr11xxIo(Spi spi, DigitalOutput reset, DigitalInput busy, DigitalInput interrupt,
-                 boolean ownsIo) {
+    Pi4jLr11xxIo(Spi spi, OnOffWrite<?> reset, OnOffRead<?> busy,
+                 ListenableOnOffRead<?> interrupt, boolean ownsIo) {
         this.ownsIo = ownsIo;
         this.spi = spi;
         this.reset = reset;
         this.busy = busy;
         this.interrupt = interrupt;
 
-        requireUndebounced("busy", busy.config().debounce());
-        requireUndebounced("interrupt", interrupt.config().debounce());
+        requireUndebounced("busy", busy);
+        requireUndebounced("interrupt", interrupt);
 
-        interrupt.addListener(edgeListener);
+        interrupt.addConsumer(edgeListener);
     }
 
     /**
@@ -103,7 +114,18 @@ class Pi4jLr11xxIo implements Lr11xxIo {
      * fix the input — the caller built it — and a radio that never receives is a
      * worse outcome than a constructor that will not run. Neither of these lines
      * comes from anything that bounces; they are chip outputs.
+     *
+     * <p>Only a Pi4J {@code DigitalInput} carries a debounce setting. A line that
+     * arrives as something else — an expander pin, a test double — has no kernel
+     * window to get wrong, so there is nothing to refuse.
      */
+    private static void requireUndebounced(String which, OnOffRead<?> line) {
+        if (line instanceof DigitalInput input) {
+            requireUndebounced(which, input.config().debounce());
+        }
+    }
+
+    /** The check itself, on the value, so it can be tested without a GPIO line. */
     static void requireUndebounced(String which, Long debounce) {
         if (debounce != null && debounce != 0L) {
             throw new IllegalArgumentException(("The %s line is debounced by %d us, which for an"
@@ -132,7 +154,7 @@ class Pi4jLr11xxIo implements Lr11xxIo {
     @Override
     public void awaitReady(Duration timeout) {
         long deadline = System.nanoTime() + timeout.toNanos();
-        while (busy.state().isHigh()) {
+        while (busy.isOn()) {
             if (System.nanoTime() > deadline) {
                 throw new IllegalStateException(
                         "The radio has been busy for " + timeout + ": either the busy wire is not"
@@ -142,11 +164,15 @@ class Pi4jLr11xxIo implements Lr11xxIo {
         }
     }
 
+    /**
+     * Pulses NRST, which is active low: the line's off state holds the radio in
+     * reset and its on state runs it.
+     */
     @Override
     public void reset() {
-        this.reset.low();
+        this.reset.off();
         sleep(RESET_PULSE);
-        this.reset.high();
+        this.reset.on();
         sleep(RESET_RECOVERY);
 
         /*
@@ -179,13 +205,24 @@ class Pi4jLr11xxIo implements Lr11xxIo {
 
     @Override
     public void close() {
-        interrupt.removeListener(edgeListener);
+        interrupt.removeConsumer(edgeListener);
 
         if (ownsIo) {
-            interrupt.close();
-            busy.close();
-            reset.close();
+            closeLine(interrupt);
+            closeLine(busy);
+            closeLine(reset);
             spi.close();
+        }
+    }
+
+    /**
+     * Closes a line the driver created itself. The lines are held as on/off
+     * interfaces, which say nothing about closing — but anything Pi4J handed out is
+     * an {@link IO}, and that does.
+     */
+    private static void closeLine(Object line) {
+        if (line instanceof IO<?, ?, ?> io) {
+            io.close();
         }
     }
 

--- a/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Pi4jLr11xxIo.java
+++ b/src/main/java/com/pi4j/drivers/radio/lora/lr11xx/Pi4jLr11xxIo.java
@@ -1,0 +1,209 @@
+package com.pi4j.drivers.radio.lora.lr11xx;
+
+import java.time.Duration;
+import java.util.concurrent.Semaphore;
+import java.util.concurrent.TimeUnit;
+
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.gpio.digital.DigitalStateChangeListener;
+import com.pi4j.io.spi.Spi;
+
+/**
+ * {@link Lr11xxIo} over Pi4J: SPI for the bytes, three digital lines for reset,
+ * busy and the interrupt.
+ *
+ * <p>Package private on purpose. It is what {@link Lr1121Driver} builds when it is
+ * handed Pi4J objects, and there is nothing here a caller needs to name.
+ */
+class Pi4jLr11xxIo implements Lr11xxIo {
+
+    /** How long a reset pulse is held, and how long the radio then needs. */
+    private static final Duration RESET_PULSE = Duration.ofMillis(5);
+    private static final Duration RESET_RECOVERY = Duration.ofMillis(300);
+
+    private static final int BUSY_POLL_MICROS = 200;
+
+    private final Spi spi;
+    private final DigitalOutput reset;
+    private final DigitalInput busy;
+    private final DigitalInput interrupt;
+
+    /**
+     * Whether the bus and the lines are ours to close.
+     *
+     * <p>They are when {@code Lr1121Driver.on(pi4j)} created them, and they are not
+     * when a caller built them and handed them over: that caller may well have
+     * plans for the pins after the radio is done with them.
+     */
+    private final boolean ownsIo;
+
+    /**
+     * Edges the radio has raised and nobody has collected yet.
+     *
+     * <p>Pi4J reports edges to a listener; this driver needs to block until one
+     * arrives. A semaphore is the bridge, and it has to be one rather than a
+     * rendezvous: the caller puts the radio into receive mode and only then starts
+     * waiting, so an edge landing in between has to be remembered rather than
+     * dropped. The kernel does exactly that with the events it queues on the line's
+     * file descriptor.
+     */
+    private final Semaphore edges = new Semaphore(0);
+
+    private final DigitalStateChangeListener edgeListener = event -> {
+        /*
+           Pi4J has no rising-edge-only request, so both edges arrive here and the
+           falling one is dropped. The radio raises the interrupt line to signal and
+           lowers it when the interrupt is cleared, so counting both would report
+           twice as many receptions as there were.
+        */
+        if (event.state().isHigh()) {
+            edges.release();
+        }
+    };
+
+    Pi4jLr11xxIo(Spi spi, DigitalOutput reset, DigitalInput busy, DigitalInput interrupt) {
+        this(spi, reset, busy, interrupt, false);
+    }
+
+    Pi4jLr11xxIo(Spi spi, DigitalOutput reset, DigitalInput busy, DigitalInput interrupt,
+                 boolean ownsIo) {
+        this.ownsIo = ownsIo;
+        this.spi = spi;
+        this.reset = reset;
+        this.busy = busy;
+        this.interrupt = interrupt;
+
+        requireUndebounced("busy", busy.config().debounce());
+        requireUndebounced("interrupt", interrupt.config().debounce());
+
+        interrupt.addListener(edgeListener);
+    }
+
+    /**
+     * Refuses a debounced input, which is the difference between this driver working
+     * and this driver looking like a dead antenna.
+     *
+     * <p>{@code DigitalInput.DEFAULT_DEBOUNCE} is 10 000 µs and an unset config
+     * materialises it, so an input built without a word about debouncing arrives
+     * here debounced by ten milliseconds. That value is not a filter in Java: Pi4J
+     * passes it to the kernel as {@code GPIO_V2_LINE_ATTR_ID_DEBOUNCE}, and the
+     * kernel then requires the line to be stable for that long before reporting
+     * anything at all. A pulse shorter than the window produces no event, not a late
+     * one.
+     *
+     * <p>This radio holds its interrupt line high only until the driver clears the
+     * interrupt — reading a buffer status, a payload and a packet status — which at a
+     * few megahertz is an order of magnitude inside that window. So the default
+     * costs every reception, silently, and the symptom is indistinguishable from a
+     * wrong spreading factor or a missing antenna. Those are the first three things
+     * anyone debugging a radio looks at, and none of them is the problem.
+     *
+     * <p>Hence an exception at construction rather than a warning. The driver cannot
+     * fix the input — the caller built it — and a radio that never receives is a
+     * worse outcome than a constructor that will not run. Neither of these lines
+     * comes from anything that bounces; they are chip outputs.
+     */
+    static void requireUndebounced(String which, Long debounce) {
+        if (debounce != null && debounce != 0L) {
+            throw new IllegalArgumentException(("The %s line is debounced by %d us, which for an"
+                    + " LR11xx means the kernel discards the pulses this driver waits for. Build"
+                    + " the input with .debounce(0L). Note that leaving debounce unset is not the"
+                    + " same thing: Pi4J defaults it to %d us.")
+                    .formatted(which, debounce, DigitalInput.DEFAULT_DEBOUNCE));
+        }
+    }
+
+    @Override
+    public void writeBytes(byte[] bytes) {
+        spi.write(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public void readBytes(byte[] into) {
+        spi.read(into, 0, into.length);
+    }
+
+    /**
+     * Polls the busy line rather than waiting on an edge. The radio is busy for
+     * microseconds after most commands, and an edge subscription set up and torn
+     * down each time would cost more than the wait.
+     */
+    @Override
+    public void awaitReady(Duration timeout) {
+        long deadline = System.nanoTime() + timeout.toNanos();
+        while (busy.state().isHigh()) {
+            if (System.nanoTime() > deadline) {
+                throw new IllegalStateException(
+                        "The radio has been busy for " + timeout + ": either the busy wire is not"
+                        + " connected, or the radio is being held in reset, or it has no power.");
+            }
+            sleepMicros(BUSY_POLL_MICROS);
+        }
+    }
+
+    @Override
+    public void reset() {
+        this.reset.low();
+        sleep(RESET_PULSE);
+        this.reset.high();
+        sleep(RESET_RECOVERY);
+
+        /*
+           A reset raises and lowers the interrupt line on its way back up, and an
+           edge left in the semaphore would be collected by the next receive() as
+           though a packet had arrived — which reads as a reception of zero bytes.
+        */
+        edges.drainPermits();
+    }
+
+    @Override
+    public boolean awaitInterrupt(Duration timeout) {
+        try {
+            if (!edges.tryAcquire(timeout.toMillis(), TimeUnit.MILLISECONDS)) {
+                return false;
+            }
+            /*
+               One wait consumes the whole burst. The caller reads the radio's
+               interrupt register to find out what happened, and that register
+               reports everything since it was last cleared — so a second permit
+               would only send it back to read a register it has already emptied.
+            */
+            edges.drainPermits();
+            return true;
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for the radio", e);
+        }
+    }
+
+    @Override
+    public void close() {
+        interrupt.removeListener(edgeListener);
+
+        if (ownsIo) {
+            interrupt.close();
+            busy.close();
+            reset.close();
+            spi.close();
+        }
+    }
+
+    private static void sleep(Duration duration) {
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while resetting the radio", e);
+        }
+    }
+
+    private static void sleepMicros(long micros) {
+        try {
+            Thread.sleep(Duration.ofNanos(micros * 1000));
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException("Interrupted while waiting for the radio", e);
+        }
+    }
+}

--- a/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121DriverHardwareTest.java
+++ b/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121DriverHardwareTest.java
@@ -1,0 +1,102 @@
+package com.pi4j.drivers.radio.lora.lr11xx;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.function.Supplier;
+
+import org.junit.jupiter.api.Assumptions;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfSystemProperty;
+
+/**
+ * The tests that need a radio on the desk, as JUnit.
+ *
+ * <p>The work itself is in {@link Lr11xxLinkCheck}, which also has a {@code main}.
+ * One implementation, two ways to reach it: Maven where there is a checkout, and a
+ * plain classpath where there is not — see that class for the {@code rsync} and
+ * {@code ssh} form, which is what to use when driving two devices from a third
+ * machine.
+ *
+ * <h2>Running these</h2>
+ *
+ * Everything here is off unless {@code lr11xx.role} says otherwise, so an ordinary
+ * build skips the lot. Run the single-radio check first, on each device:
+ *
+ * <pre>
+ * mvn test -Dtest=Lr1121DriverHardwareTest -Dlr11xx.role=check
+ * </pre>
+ *
+ * <p>A radio that will not identify itself has a wiring fault, and no amount of
+ * link debugging will find it. Once both answer, the link needs <b>two machines</b>
+ * — a radio cannot hear itself. Start the listener first:
+ *
+ * <pre>
+ * mvn test -Dtest=Lr1121DriverHardwareTest -Dlr11xx.role=receive    # on one
+ * mvn test -Dtest=Lr1121DriverHardwareTest -Dlr11xx.role=transmit   # on the other
+ * </pre>
+ *
+ * <p>Wiring and radio parameters are system properties with Waveshare Core1121
+ * defaults; {@link Lr11xxLinkCheck} lists them. Both ends must agree on the
+ * frequency and the spreading factor, and the antenna goes on before power.
+ *
+ * <h2>Why a system property rather than {@code @Disabled}</h2>
+ *
+ * The other hardware tests in this project are annotated {@code @Disabled}, which
+ * means running them requires editing the file. That is tolerable for a sensor on
+ * one desk and poor for a link, where it would mean the same edit on two machines
+ * and a dirty working tree on both. A property is skipped just as thoroughly in CI
+ * and can be turned on from the command line.
+ *
+ * <p>Note also that this project carries several Pi4J providers on the test
+ * classpath and {@code newAutoContext()} picks whichever registers, so these
+ * exercise the provider your machine ends up with rather than one they choose.
+ */
+class Lr1121DriverHardwareTest {
+
+    @Test
+    @EnabledIfSystemProperty(named = "lr11xx.role", matches = "check")
+    void theRadioIdentifiesItselfAndConfigures() {
+        Lr1121Driver.Version version = run(Lr11xxLinkCheck::check);
+
+        assertNotNull(version);
+        assertTrue(version.hardware() != 0x00 && version.hardware() != 0xFF,
+                "the chip answered with " + version + ", which is what an unconnected MISO"
+                + " line looks like — check the wiring before anything else");
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "lr11xx.role", matches = "transmit")
+    void transmits() {
+        assertTrue(run(Lr11xxLinkCheck::transmit) > 0,
+                "the time ran out before a single packet was sent");
+    }
+
+    @Test
+    @EnabledIfSystemProperty(named = "lr11xx.role", matches = "receive")
+    void receives() {
+        assertTrue(run(Lr11xxLinkCheck::receive) > 0, Lr11xxLinkCheck.NOTHING_HEARD);
+    }
+
+    /**
+     * Runs one of the checks, turning "there is no radio here" into a skip.
+     *
+     * <p>Aborting rather than failing is how the other hardware tests here behave,
+     * and it is the right answer: somebody who asked for this role on a machine
+     * without the wiring should be told, not accused.
+     *
+     * <p>{@code LinkageError} as well as {@code Exception}, because a Pi4J provider
+     * that cannot load its native library throws an {@code Error} — which would
+     * otherwise sail past this and report a missing radio as a stack trace about a
+     * shared object file.
+     */
+    private static <T> T run(Supplier<T> check) {
+        try {
+            return check.get();
+        } catch (Exception | LinkageError e) {
+            e.printStackTrace();
+            Assumptions.abort("No usable LR11xx on " + Lr11xxLinkCheck.wiring() + " (" + e + ")");
+            throw new IllegalStateException(e);
+        }
+    }
+}

--- a/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121DriverTest.java
@@ -75,16 +75,16 @@ class Lr1121DriverTest {
     // Bringing the radio up
     // ------------------------------------------------------------------
 
+    /** An LR1121 that has finished booting, which configure() waits for. */
+    private void radioHasBooted() {
+        transport.willAnswer(0x22, 0x03, 0x01, 0x01);
+    }
+
     /**
      * The board's own values reach the chip unchanged. These are the numbers that
      * cannot be derived from anything — they describe how the module was wired —
      * so the test states them literally, as the vendor's demo does.
      */
-    /** An LR1121 that has finished booting, which configure() now waits for. */
-    private void radioHasBooted() {
-        transport.willAnswer(0x22, 0x03, 0x01, 0x01);
-    }
-
     @Test
     void theBoardConfigurationIsSentAsTheVendorSendsIt() {
         radioHasBooted();

--- a/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121DriverTest.java
+++ b/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Lr1121DriverTest.java
@@ -1,0 +1,456 @@
+package com.pi4j.drivers.radio.lora.lr11xx;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.time.Duration;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The bytes this driver puts on the wire, checked against the ones Semtech's own
+ * C driver sends.
+ *
+ * <p>That is the whole point of this test class. The radio cannot be asked
+ * whether a command was understood — a wrong byte produces a receiver that hears
+ * nothing, with no error anywhere — so the only way to be sure without hardware
+ * is to compare against a reference implementation, command by command. The
+ * reference is SWDR001, which Waveshare ships with the Core1121 demo.
+ */
+class Lr1121DriverTest {
+
+    private final RecordingIo transport = new RecordingIo();
+    private final Lr1121Driver radio = new Lr1121Driver(transport);
+
+    // ------------------------------------------------------------------
+    // The shape every command has
+    // ------------------------------------------------------------------
+
+    /**
+     * A command is a big-endian opcode and then its arguments. Getting the byte
+     * order backwards is the mistake that produces a radio which answers nothing,
+     * so it is worth one test of its own.
+     */
+    @Test
+    void aCommandIsABigEndianOpcodeFollowedByItsArguments() {
+        radio.standby();
+
+        // SetStandby, 0x011C, with the "RC oscillator" argument.
+        assertEquals("011C00", transport.transactions().getFirst());
+    }
+
+    /**
+     * A command that answers takes two transactions with a wait between them, and
+     * the radio sends a status byte before the answer. Dropping that byte is the
+     * difference between reading a firmware version and reading nonsense shifted
+     * by one.
+     */
+    @Test
+    void anAnswerArrivesAfterAStatusByteThatIsNotPartOfIt() {
+        transport.willAnswer(0x22, 0x01, 0x03, 0x07);
+
+        Lr1121Driver.Version version = radio.version();
+
+        assertEquals("0101", transport.transactions().getFirst());
+        assertEquals(0x22, version.hardware());
+        assertEquals(0x01, version.useCase());
+        assertEquals(0x0307, version.firmware());
+    }
+
+    /** The radio is asked to be ready before every transaction, never assumed to be. */
+    @Test
+    void theBusyLineIsWaitedForBeforeSpeaking() {
+        transport.willAnswer(0x00, 0x00, 0x00, 0x00);
+
+        radio.version();
+
+        assertEquals(2, transport.readyWaits,
+                "once before the command and once before reading the answer");
+    }
+
+    // ------------------------------------------------------------------
+    // Bringing the radio up
+    // ------------------------------------------------------------------
+
+    /**
+     * The board's own values reach the chip unchanged. These are the numbers that
+     * cannot be derived from anything — they describe how the module was wired —
+     * so the test states them literally, as the vendor's demo does.
+     */
+    /** An LR1121 that has finished booting, which configure() now waits for. */
+    private void radioHasBooted() {
+        transport.willAnswer(0x22, 0x03, 0x01, 0x01);
+    }
+
+    @Test
+    void theBoardConfigurationIsSentAsTheVendorSendsIt() {
+        radioHasBooted();
+        radio.configure(Lr1121Driver.BoardConfig.core1121());
+
+        // SetTcxoMode: 3.0 V, 300 ticks of 30.52 us.
+        assertTrue(transport.wrote("01170600012C"), transport.transactions().toString());
+        // SetDioAsRfSwitch: enable RFSW0|RFSW1, standby 0, rx RFSW0, tx RFSW1,
+        // tx_hp RFSW1, tx_hf 0, gnss 0, wifi 0.
+        assertTrue(transport.wrote("01120300010202000000"), transport.transactions().toString());
+    }
+
+    /**
+     * The oscillator is configured before the calibration, not after. Calibrating
+     * first trims the radio against a clock it is about to stop using, and the
+     * result is a quiet receiver rather than an error.
+     */
+    @Test
+    void theOscillatorIsConfiguredBeforeCalibrating() {
+        radioHasBooted();
+        radio.configure(Lr1121Driver.BoardConfig.core1121());
+
+        int tcxo = indexOfCommand("0117");
+        int calibrate = indexOfCommand("010F");
+        assertTrue(tcxo < calibrate,
+                "SetTcxoMode at %d should come before Calibrate at %d".formatted(tcxo, calibrate));
+    }
+
+    @Test
+    void configuringResetsTheRadioFirst() {
+        radioHasBooted();
+        radio.configure(Lr1121Driver.BoardConfig.core1121());
+
+        assertEquals(1, transport.resets);
+    }
+
+    /** A board with no crystal oscillator is not told to wait for one. */
+    @Test
+    void aBoardWithoutATcxoIsNotSentTheCommand() {
+        Lr1121Driver.BoardConfig noTcxo = new Lr1121Driver.BoardConfig(Lr1121Driver.BoardConfig.NO_TCXO, 0,
+                Lr1121Driver.BoardConfig.RFSW0, 0, Lr1121Driver.BoardConfig.RFSW0, 0, 0, 0,
+                Lr1121Driver.BoardConfig.PA_HIGH_POWER, Lr1121Driver.BoardConfig.PA_SUPPLY_BATTERY, 0x04, 0x07);
+
+        radioHasBooted();
+        radio.configure(noTcxo);
+
+        assertTrue(transport.transactions().stream().noneMatch(t -> t.startsWith("0117")),
+                "SetTcxoMode should not be sent: " + transport.transactions());
+    }
+
+    /**
+     * An LR11xx starts in a bootloader that checks its flash and then hands over
+     * to the application firmware. Asked during that window it answers as the
+     * bootloader, which accepts firmware updates and refuses everything else — so
+     * configuring immediately produces a radio that fails every command for a
+     * reason that looks nothing like impatience.
+     */
+    @Test
+    void configuringWaitsForTheBootloaderToHandOver() {
+        transport.willAnswer(0x22, 0xDF, 0x00, 0x00);   // still booting
+        transport.willAnswer(0x22, 0xDF, 0x00, 0x00);   // still booting
+        radioHasBooted();
+
+        radio.configure(Lr1121Driver.BoardConfig.core1121());
+
+        assertTrue(transport.wrote("01170600012C"),
+                "and once it has, the configuration goes out as usual");
+    }
+
+    /** A module whose firmware is genuinely missing says so rather than hanging. */
+    @Test
+    void aRadioThatNeverLeavesItsBootloaderIsReported() {
+        transport.willKeepAnswering(0x22, 0xDF, 0x00, 0x00);
+
+        IllegalStateException failure = assertThrows(IllegalStateException.class,
+                () -> radio.configure(Lr1121Driver.BoardConfig.core1121()));
+
+        assertTrue(failure.getMessage().contains("bootloader"), failure.getMessage());
+    }
+
+    // ------------------------------------------------------------------
+    // The modulation
+    // ------------------------------------------------------------------
+
+    @Test
+    void theFrequencyIsSentAsFourBigEndianBytes() {
+        radio.configureLora(868_100_000L, Lr1121Driver.LoraSettings.defaults());
+
+        // 868100000 = 0x33BE27A0
+        assertTrue(transport.wrote("020B33BE27A0"), transport.transactions().toString());
+    }
+
+    @Test
+    void theModulationIsSpreadingFactorBandwidthCodingRateAndTheOptimisation() {
+        radio.configureLora(868_100_000L, Lr1121Driver.LoraSettings.defaults());
+
+        // SF9, BW 125 kHz, CR 4/5, low data rate optimisation off.
+        assertEquals("020F09040100", transport.transactionFor("020F"));
+    }
+
+    /**
+     * The low data rate optimisation is derived rather than configured, because
+     * both ends have to make the same decision and a link where one of them did
+     * not is a link that silently does not work. It is required when a symbol
+     * lasts longer than 16 ms.
+     */
+    @Test
+    void theLowDataRateOptimisationFollowsFromTheSymbolLength() {
+        // SF9 at 125 kHz: 4.1 ms per symbol.
+        assertEquals(false, Lr1121Driver.LoraSettings.defaults().lowDataRateOptimisation());
+        // SF11: 16.4 ms, just over the line.
+        assertEquals(true, Lr1121Driver.LoraSettings.defaults().withSpreadingFactor(11).lowDataRateOptimisation());
+        assertEquals(true, Lr1121Driver.LoraSettings.defaults().withSpreadingFactor(12).lowDataRateOptimisation());
+        // SF11 at 500 kHz is back under it.
+        assertEquals(false, new Lr1121Driver.LoraSettings(11, Lr1121Driver.LoraSettings.BW_500_KHZ, Lr1121Driver.LoraSettings.CR_4_5,
+                Lr1121Driver.LoraSettings.SYNC_WORD_PRIVATE, 8, true, true, false).lowDataRateOptimisation());
+    }
+
+    /**
+     * The image calibration is done for the band the radio was just pointed at,
+     * because it is the one calibration that is about a band rather than about
+     * the chip. Skipping it costs sensitivity and reports nothing at the time,
+     * which is the worst way for a radio to be wrong.
+     *
+     * <p>The band edges are in units of 4 MHz rounded outwards, so 868.1 MHz
+     * becomes 860 to 880 — one step wider than the 0xD7 to 0xDB the vendor uses
+     * for 863-870, and containing it. Wider costs nothing here: the calibration
+     * is of a filter, and a band that covers the channel is what it needs to be.
+     */
+    @Test
+    void theImageIsCalibratedForTheBandInUse() {
+        radio.configureLora(868_100_000L, Lr1121Driver.LoraSettings.defaults());
+
+        assertEquals("0111D7DC", transport.transactionFor("0111"));
+        assertTrue(indexOfCommand("020B") < indexOfCommand("0111"),
+                "the frequency is set before the band around it is calibrated");
+    }
+
+    /** And it follows the frequency rather than being fixed to one band. */
+    @Test
+    void anotherBandIsCalibratedForItself() {
+        radio.configureLora(434_000_000L, Lr1121Driver.LoraSettings.defaults());
+
+        // (434 - 8) / 4 = 106.5 -> 106 = 0x6A, (434 + 8) / 4 = 110.5 -> 111 = 0x6F
+        assertEquals("01116A6F", transport.transactionFor("0111"));
+    }
+
+    @Test
+    void theSyncWordSeparatesAPrivateLinkFromALoRaWANOne() {
+        radio.configureLora(868_100_000L, Lr1121Driver.LoraSettings.defaults());
+
+        assertEquals("022B12", transport.transactionFor("022B"));
+    }
+
+    // ------------------------------------------------------------------
+    // Receiving
+    // ------------------------------------------------------------------
+
+    /**
+     * GetStatus is a direct read: bytes clocked out with no command sent first,
+     * and no status byte in front of them because the first byte is one.
+     *
+     * <p>Worth a test of its own because of how it failed. Read as an ordinary
+     * command, the interrupt word comes out shifted one byte left, so RX_DONE
+     * reads as 0x0800 instead of 0x08 — the interrupt fires, the flags are read,
+     * and every packet is dropped as "not a reception". Nothing errors anywhere.
+     */
+    @Test
+    void theInterruptFlagsAreReadWithoutSendingACommand() {
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x08);
+
+        assertEquals(Lr1121Driver.IRQ_RX_DONE, radio.irqStatus());
+        assertEquals(0, transport.transactionCount(),
+                "a direct read sends nothing at all");
+    }
+
+    /** And the whole 32 bit word is assembled, not just its last byte. */
+    @Test
+    void theWholeInterruptWordIsRead() {
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x40, 0x00, 0x08);
+
+        assertEquals(0x00400008, radio.irqStatus());
+    }
+
+    @Test
+    void aPacketIsReadFromWhereTheRadioSaysItIs() {
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x08);   // GetStatus: RX done
+        transport.willAnswer(0x03, 0x80);                            // 3 bytes at offset 0x80
+        transport.willAnswer(0xAA, 0xBB, 0xCC);                      // ReadBuffer8
+        transport.willAnswer(0x94, 0x14, 0x00);                      // RSSI -74, SNR 5
+
+        Lr1121Driver.ReceivedPacket packet = radio.receive(Lr1121Driver.LoraSettings.defaults(), Duration.ofSeconds(1))
+                .orElseThrow();
+
+        assertArrayEquals(new byte[] {(byte) 0xAA, (byte) 0xBB, (byte) 0xCC}, packet.payload());
+        // ReadBuffer8 is given the offset and the length the radio just reported.
+        assertEquals("010A8003", transport.transactionFor("010A"));
+    }
+
+    /** The two numbers that say whether a link is comfortable or marginal. */
+    @Test
+    void theSignalQualityIsDecodedAsTheDatasheetScalesIt() {
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x08);
+        transport.willAnswer(0x01, 0x00);
+        transport.willAnswer(0x42);
+        transport.willAnswer(0x94, 0x14, 0x00);
+
+        Lr1121Driver.ReceivedPacket packet = radio.receive(Lr1121Driver.LoraSettings.defaults(), Duration.ofSeconds(1))
+                .orElseThrow();
+
+        assertEquals(-74, packet.rssiDbm(), "0x94 is 148, and RSSI is minus half of it");
+        assertEquals(5.0, packet.snrDb(), 0.01, "0x14 is 20, and SNR is a quarter of it");
+    }
+
+    /**
+     * A packet the radio knows is corrupt is not a packet. Handing the bytes back
+     * with a warning would put the decision in every caller, and the answer is
+     * always the same.
+     */
+    @Test
+    void aPacketThatFailedItsCrcIsNotReturned() {
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x88);   // RX done and CRC error
+
+        assertEquals(Optional.empty(),
+                radio.receive(Lr1121Driver.LoraSettings.defaults(), Duration.ofSeconds(1)));
+    }
+
+    /** Hearing nothing is the ordinary case, not a failure. */
+    @Test
+    void aTimeoutIsEmptyRatherThanAnException() {
+        transport.interruptFires = false;
+        transport.willKeepAnsweringDirectly(0, 0, 0, 0, 0, 0);   // no flags, ever
+
+        assertEquals(Optional.empty(),
+                radio.receive(Lr1121Driver.LoraSettings.defaults(), Duration.ofMillis(50)));
+    }
+
+    /**
+     * The interrupt line is a hint and the flags are the truth. A receiver whose
+     * interrupt wire is dead still hears packets, a fifth of a second late — which
+     * is the difference between a link that works and one that is silent for a
+     * reason nothing reports.
+     */
+    @Test
+    void aPacketIsFoundEvenIfTheInterruptNeverFires() {
+        transport.interruptFires = false;
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x08);
+        transport.willAnswer(0x01, 0x00);
+        transport.willAnswer(0x42);
+        transport.willAnswer(0x94, 0x14, 0x00);
+
+        assertTrue(radio.receive(Lr1121Driver.LoraSettings.defaults(), Duration.ofSeconds(1)).isPresent());
+    }
+
+    /**
+     * The receiver is told to listen indefinitely and the waiting is done on this
+     * side. Leaving it to the radio's own timeout would mean a receiver that
+     * cannot be interrupted.
+     */
+    @Test
+    void theRadioIsToldToListenUntilItIsToldOtherwise() {
+        transport.interruptFires = false;
+        transport.willKeepAnsweringDirectly(0, 0, 0, 0, 0, 0);
+
+        radio.receive(Lr1121Driver.LoraSettings.defaults(), Duration.ofMillis(50));
+
+        assertEquals("0209000000", transport.transactionFor("0209"));
+    }
+
+    // ------------------------------------------------------------------
+    // Sending
+    // ------------------------------------------------------------------
+
+    @Test
+    void aPayloadIsWrittenToTheBufferBeforeItIsSent() {
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x04);   // TX done
+
+        radio.transmit(new byte[] {0x01, 0x02, 0x03}, Lr1121Driver.LoraSettings.defaults(), 14,
+                Duration.ofSeconds(5));
+
+        assertEquals("0109010203", transport.transactionFor("0109"));
+        assertTrue(indexOfCommand("0109") < indexOfCommand("020A"),
+                "the buffer has to be filled before the transmission starts");
+    }
+
+    /** The packet parameters carry the length, so they follow the payload. */
+    @Test
+    void theLengthIsSentWithThePacketParameters() {
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x04);
+
+        radio.transmit(new byte[16], Lr1121Driver.LoraSettings.defaults(), 14, Duration.ofSeconds(5));
+
+        // preamble 8, explicit header, 16 bytes, CRC on, IQ standard.
+        assertEquals("021000080010" + "0100", transport.transactionFor("0210"));
+    }
+
+    /**
+     * The amplifier comes from the board, not from the power asked for.
+     *
+     * <p>A module routes one of the chip's outputs to its antenna and leaves the
+     * others unconnected. Choosing by power — low path below 14 dBm, high above —
+     * therefore transmits into a pin that goes nowhere for half the range, on a
+     * board like the Core1121 that only wires the high power output. Nothing
+     * reports it: the radio transmits and the far end hears the leakage.
+     *
+     * <p>The order is select, supply, duty cycle, size.
+     */
+    @Test
+    void theAmplifierComesFromTheBoardRatherThanFromThePower() {
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x04);
+        radio.configure(Lr1121Driver.BoardConfig.core1121());
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x04);
+
+        radio.transmit(new byte[1], Lr1121Driver.LoraSettings.defaults(), 14, Duration.ofSeconds(5));
+
+        // High power amplifier, from the battery, duty 0x04, size 0x07.
+        assertEquals("021501010407", transport.transactionFor("0215"));
+    }
+
+    /** And a low power output is asked for only when the board actually has one. */
+    @Test
+    void aBoardWiredToItsLowPowerOutputSaysSo() {
+        Lr1121Driver.BoardConfig lowPower = new Lr1121Driver.BoardConfig(Lr1121Driver.BoardConfig.NO_TCXO, 0,
+                Lr1121Driver.BoardConfig.RFSW0, 0, Lr1121Driver.BoardConfig.RFSW0, 0, 0, 0,
+                Lr1121Driver.BoardConfig.PA_LOW_POWER, Lr1121Driver.BoardConfig.PA_SUPPLY_REGULATOR, 0x04, 0x00);
+        transport.willAnswer(0x22, 0x03, 0x01, 0x01);
+        radio.configure(lowPower);
+        transport.willAnswerDirectly(0x00, 0x00, 0x00, 0x00, 0x00, 0x04);
+
+        radio.transmit(new byte[1], Lr1121Driver.LoraSettings.defaults(), 14, Duration.ofSeconds(5));
+
+        assertEquals("021500000400", transport.transactionFor("0215"));
+    }
+
+    @Test
+    void aTransmissionThatIsNeverConfirmedIsAnError() {
+        transport.interruptFires = false;
+
+        assertThrows(IllegalStateException.class, () -> radio.transmit(
+                new byte[1], Lr1121Driver.LoraSettings.defaults(), 14, Duration.ofSeconds(5)));
+    }
+
+    @Test
+    void aPayloadTooLargeForAPacketIsRefusedBeforeTheRadioSeesIt() {
+        assertThrows(IllegalArgumentException.class, () -> radio.transmit(
+                new byte[256], Lr1121Driver.LoraSettings.defaults(), 14, Duration.ofSeconds(5)));
+
+        assertEquals(0, transport.transactionCount());
+    }
+
+    // ------------------------------------------------------------------
+
+    @Test
+    void closingTheRadioClosesTheWires() {
+        radio.close();
+
+        assertTrue(transport.closed);
+    }
+
+    private int indexOfCommand(String opcodeHex) {
+        var transactions = transport.transactions();
+        for (int i = 0; i < transactions.size(); i++) {
+            if (transactions.get(i).startsWith(opcodeHex)) {
+                return i;
+            }
+        }
+        throw new AssertionError("No command " + opcodeHex + " among " + transactions);
+    }
+}

--- a/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Lr11xxLinkCheck.java
+++ b/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Lr11xxLinkCheck.java
@@ -1,0 +1,275 @@
+package com.pi4j.drivers.radio.lora.lr11xx;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Optional;
+
+import com.pi4j.Pi4J;
+import com.pi4j.context.Context;
+import com.pi4j.io.spi.SpiChipSelect;
+
+/**
+ * Tries an LR11xx on real hardware, from a {@code main} as well as from a test.
+ *
+ * <h2>Why a main as well</h2>
+ *
+ * A radio cannot hear itself, so proving this driver means two machines at once —
+ * and the convenient way to drive two machines is over SSH from a third. Maven on
+ * the far end works and is what {@link Lr1121DriverHardwareTest} documents, but it
+ * wants a checkout, a settings file and a warm repository on every device. A class
+ * with a {@code main} wants a JRE and a directory of jars, which {@code rsync}
+ * puts there in one go:
+ *
+ * <pre>
+ * mvn -q test-compile dependency:copy-dependencies -DincludeScope=test
+ * rsync -a target/classes target/test-classes target/dependency pi-b:/tmp/lr11xx/
+ * ssh pi-b 'cd /tmp/lr11xx &amp;&amp; java --enable-native-access=ALL-UNNAMED \
+ *     -cp "classes:test-classes:dependency/*" \
+ *     com.pi4j.drivers.radio.lora.lr11xx.Lr11xxLinkCheck receive'
+ * </pre>
+ *
+ * <p>Roles are {@code check}, {@code transmit} and {@code receive}. Run
+ * {@code check} first on each machine: it asks the chip what it is, and a radio
+ * that will not answer has a wiring fault that no amount of link debugging will
+ * find. Then start {@code receive} on one and {@code transmit} on the other.
+ *
+ * <h2>The wiring these defaults assume</h2>
+ *
+ * A Waveshare Core1121 on a Raspberry Pi's 40 pin header, SPI0:
+ *
+ * <pre>
+ *   Core1121   Raspberry Pi   BCM   Header pin
+ *   ------------------------------------------
+ *   VCC        3V3             -    1
+ *   GND        GND             -    6
+ *   SCK        SPI0 SCLK      11    23
+ *   MOSI       SPI0 MOSI      10    19
+ *   MISO       SPI0 MISO       9    21
+ *   NSS        SPI0 CE0        8    24
+ *   RESET      GPIO           22    15
+ *   BUSY       GPIO           24    18
+ *   DIO9       GPIO           23    16
+ * </pre>
+ *
+ * <p><b>DIO9, not DIO1.</b> The Core1121 brings several DIO pins out and only one of
+ * them carries the interrupt this driver waits on.
+ *
+ * <p>The first six rows are not configurable here and do not need to be: they follow
+ * from the SPI bus and chip select, and the kernel drives NSS around each transfer.
+ * Only the last three are pin numbers this code passes to Pi4J. <b>The BCM column is
+ * the one that matters</b> — that is what the properties below take. The header pin
+ * column is for wiring by eye and nothing reads it.
+ *
+ * <p>Enable SPI first, or the bus will not exist: {@code sudo raspi-config} →
+ * Interface Options → SPI. The process also needs {@code spi}, {@code gpio},
+ * {@code dialout} and {@code i2c} — Pi4J's FFM provider checks the last two even
+ * for a device that uses neither, and it reads the group database, so
+ * {@code usermod -aG} rather than a systemd unit's {@code SupplementaryGroups=}.
+ *
+ * <h2>Parameters</h2>
+ *
+ * Override any of it with system properties, which work the same from Maven and
+ * from the command line:
+ *
+ * <pre>
+ * -Dlr11xx.bus=0 -Dlr11xx.reset=22 -Dlr11xx.busy=24 -Dlr11xx.irq=23
+ * -Dlr11xx.frequency=868000000 -Dlr11xx.sf=7 -Dlr11xx.power=14 -Dlr11xx.seconds=30
+ * </pre>
+ *
+ * <p><b>Both ends must agree on the frequency and the spreading factor.</b> There is
+ * no negotiation in LoRa and no error when two ends disagree — a mismatch and a
+ * missing antenna both sound like silence — so change them together, and one at a
+ * time.
+ *
+ * <p>The antenna goes on before power. A transmitter driving an open port is a
+ * transmitter damaging itself.
+ */
+public final class Lr11xxLinkCheck {
+
+    /** Waveshare's own numbers for the Core1121 on a Raspberry Pi. */
+    static final int BUS = intProperty("lr11xx.bus", 0);
+    static final int RESET_PIN = intProperty("lr11xx.reset", 22);
+    static final int BUSY_PIN = intProperty("lr11xx.busy", 24);
+    static final int IRQ_PIN = intProperty("lr11xx.irq", 23);
+
+    static final long FREQUENCY_HZ = longProperty("lr11xx.frequency", 868_000_000L);
+    static final int SPREADING_FACTOR = intProperty("lr11xx.sf", 7);
+
+    /** 14 dBm is the EU868 limit on most channels. */
+    static final int POWER_DBM = intProperty("lr11xx.power", 14);
+
+    /** How long the receiver waits, and how long the transmitter keeps sending. */
+    static final Duration DURATION = Duration.ofSeconds(longProperty("lr11xx.seconds", 30));
+
+    private Lr11xxLinkCheck() {
+    }
+
+    public static void main(String[] args) {
+        String role = args.length > 0 ? args[0] : System.getProperty("lr11xx.role", "check");
+        try {
+            switch (role) {
+                case "check" -> System.out.println("Radio reports: " + check());
+                case "transmit" -> System.out.println("Sent " + transmit() + " packet(s)");
+                case "receive" -> {
+                    int heard = receive();
+                    System.out.println("Heard " + heard + " packet(s)");
+                    if (heard == 0) {
+                        System.err.println(NOTHING_HEARD);
+                        System.exit(1);
+                    }
+                }
+                default -> {
+                    System.err.println("Roles are: check, transmit, receive");
+                    System.exit(2);
+                }
+            }
+        } catch (Exception | LinkageError e) {
+            /*
+               LinkageError too. Several Pi4J providers may be on the classpath and
+               the auto context picks whichever registers, so a machine where one
+               declines can end up on another that then fails to load its native
+               library — an Error, which would otherwise leave no explanation.
+            */
+            e.printStackTrace();
+            System.exit(1);
+        }
+    }
+
+    static final String NOTHING_HEARD =
+            "Nothing arrived. Either the transmitter is not running, or the two ends disagree:"
+            + " compare the frequency, the spreading factor and the CRC setting, and check that"
+            + " both antennas are on. A mismatch sounds exactly like a missing antenna.";
+
+    /**
+     * Asks the chip what it is, then configures it.
+     *
+     * @return what it said, so a caller can judge it. Zeros or 0xFF mean the wiring
+     *         rather than anything the radio did
+     */
+    static Lr1121Driver.Version check() {
+        Context pi4j = context();
+        try (Lr1121Driver radio = radio(pi4j)) {
+            Lr1121Driver.Version version = radio.version();
+            System.out.println("Radio reports: " + version);
+
+            radio.configure(Lr1121Driver.BoardConfig.core1121());
+            radio.configureLora(FREQUENCY_HZ, settings());
+
+            int errors = radio.errors();
+            if (errors != 0) {
+                throw new IllegalStateException(("The chip reports errors 0x%04X after"
+                        + " configuring. On this board that is usually the TCXO voltage.")
+                        .formatted(errors));
+            }
+            return version;
+        } finally {
+            shutdownQuietly(pi4j);
+        }
+    }
+
+    /** Sends until the time runs out. Start the listener on the other machine first. */
+    static int transmit() {
+        Context pi4j = context();
+        try (Lr1121Driver radio = radio(pi4j)) {
+            radio.configure(Lr1121Driver.BoardConfig.core1121());
+            radio.configureLora(FREQUENCY_HZ, settings());
+
+            System.out.printf("Sending on %.3f MHz, SF%d, %d dBm for %s%n",
+                    FREQUENCY_HZ / 1e6, SPREADING_FACTOR, POWER_DBM, DURATION);
+
+            int sent = 0;
+            Instant deadline = Instant.now().plus(DURATION);
+            while (Instant.now().isBefore(deadline)) {
+                byte[] payload = ("pi4j-drivers " + sent).getBytes();
+                radio.transmit(payload, settings(), POWER_DBM, Duration.ofSeconds(10));
+                sent++;
+                System.out.println("  sent " + new String(payload));
+                sleep(Duration.ofSeconds(2));
+            }
+            return sent;
+        } finally {
+            shutdownQuietly(pi4j);
+        }
+    }
+
+    /** Listens for the duration and reports what arrived, with its signal strength. */
+    static int receive() {
+        Context pi4j = context();
+        try (Lr1121Driver radio = radio(pi4j)) {
+            radio.configure(Lr1121Driver.BoardConfig.core1121());
+            radio.configureLora(FREQUENCY_HZ, settings());
+
+            System.out.printf("Listening on %.3f MHz, SF%d for %s%n",
+                    FREQUENCY_HZ / 1e6, SPREADING_FACTOR, DURATION);
+
+            int heard = 0;
+            Instant deadline = Instant.now().plus(DURATION);
+            while (Instant.now().isBefore(deadline)) {
+                Optional<Lr1121Driver.ReceivedPacket> packet =
+                        radio.receive(settings(), Duration.ofSeconds(5));
+                if (packet.isPresent()) {
+                    heard++;
+                    System.out.printf("  %d bytes, RSSI %d dBm, SNR %.1f dB: %s%n",
+                            packet.get().payload().length, packet.get().rssiDbm(),
+                            packet.get().snrDb(), new String(packet.get().payload()));
+                }
+            }
+            return heard;
+        } finally {
+            shutdownQuietly(pi4j);
+        }
+    }
+
+    // ------------------------------------------------------------------
+
+    static Lr1121Driver.LoraSettings settings() {
+        return Lr1121Driver.LoraSettings.defaults()
+                .withSpreadingFactor(SPREADING_FACTOR)
+                .withCrc(false);
+    }
+
+    static Context context() {
+        return Pi4J.newAutoContext();
+    }
+
+    static Lr1121Driver radio(Context pi4j) {
+        return new Lr1121Driver(pi4j, BUS, SpiChipSelect.CS_0, RESET_PIN, BUSY_PIN, IRQ_PIN);
+    }
+
+    /**
+     * A shutdown that throws must not replace what the run was actually reporting.
+     * In a {@code finally} block it would, and then a clean "no radio here" arrives
+     * as an error about the shutdown.
+     */
+    static void shutdownQuietly(Context pi4j) {
+        try {
+            pi4j.shutdown();
+        } catch (Exception | LinkageError e) {
+            System.out.println("Pi4J shutdown complained, which is not the result: "
+                    + e.getMessage());
+        }
+    }
+
+    static String wiring() {
+        return "SPI bus " + BUS + " with reset/busy/irq on BCM "
+                + RESET_PIN + "/" + BUSY_PIN + "/" + IRQ_PIN;
+    }
+
+    private static void sleep(Duration duration) {
+        try {
+            Thread.sleep(duration);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new IllegalStateException(e);
+        }
+    }
+
+    private static int intProperty(String name, int fallback) {
+        return (int) longProperty(name, fallback);
+    }
+
+    private static long longProperty(String name, long fallback) {
+        String value = System.getProperty(name);
+        return value == null || value.isBlank() ? fallback : Long.parseLong(value.trim());
+    }
+}

--- a/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Pi4jLr11xxIoTest.java
+++ b/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Pi4jLr11xxIoTest.java
@@ -1,21 +1,27 @@
 package com.pi4j.drivers.radio.lora.lr11xx;
 
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
+
+import com.pi4j.io.ListenableOnOffRead;
 import com.pi4j.io.gpio.digital.DigitalInput;
 
 import org.junit.jupiter.api.Test;
 
 /**
- * The one part of the Pi4J binding that can be checked without a radio, and the
- * part most likely to save somebody an evening.
+ * What the Pi4J binding does around the bytes, checked without a radio: the
+ * debounce refusal, the lines taken as plain on/off interfaces, and what a reset
+ * leaves behind.
  *
- * <p>A debounced input is not a slower driver, it is a driver that receives
- * nothing: Pi4J passes the value to the kernel, which then reports no event at all
- * for a pulse shorter than the window. This radio's pulses are far shorter than the
- * ten milliseconds Pi4J defaults to.
+ * <p>The debounce refusal is the part most likely to save somebody an evening. A
+ * debounced input is not a slower driver, it is a driver that receives nothing:
+ * Pi4J passes the value to the kernel, which then reports no event at all for a
+ * pulse shorter than the window. This radio's pulses are far shorter than the ten
+ * milliseconds Pi4J defaults to.
  */
 class Pi4jLr11xxIoTest {
 
@@ -60,5 +66,55 @@ class Pi4jLr11xxIoTest {
     @Test
     void anAbsentValueIsNotADebounce() {
         assertDoesNotThrow(() -> Pi4jLr11xxIo.requireUndebounced("interrupt", null));
+    }
+
+    /**
+     * The three lines are on/off interfaces rather than GPIO objects so that an I/O
+     * expander's pins can carry them. This is that case: plain on/off lines, no
+     * {@code DigitalInput} anywhere, and the driver still waits on the interrupt and
+     * still polls busy.
+     *
+     * <p>The SPI bus is null on purpose — nothing checked here moves a byte, and a
+     * fake bus would only be a place for a mistake to hide.
+     */
+    @Test
+    void linesThatAreNotGpioObjectsStillWork() {
+        ListenableOnOffRead.Impl busy = new ListenableOnOffRead.Impl(false);
+        ListenableOnOffRead.Impl interrupt = new ListenableOnOffRead.Impl(false);
+
+        try (Pi4jLr11xxIo io = new Pi4jLr11xxIo(null, new ListenableOnOffRead.Impl(true),
+                busy, interrupt)) {
+            assertDoesNotThrow(() -> io.awaitReady(Duration.ofMillis(50)),
+                    "a line that is off is a radio that is ready");
+
+            assertFalse(io.awaitInterrupt(Duration.ofMillis(20)),
+                    "nothing has happened, so the wait has to time out");
+
+            interrupt.setState(true);
+            assertTrue(io.awaitInterrupt(Duration.ofMillis(20)),
+                    "the edge the line just raised is what the driver waits for");
+        }
+    }
+
+    /**
+     * Reset is active low, and the line is left switched on — which for a directly
+     * wired NRST is high, and for an inverted one is whatever the caller declared on
+     * to be. A radio left in reset answers nothing.
+     */
+    @Test
+    void resetLeavesTheLineOn() {
+        ListenableOnOffRead.Impl reset = new ListenableOnOffRead.Impl(true);
+        ListenableOnOffRead.Impl interrupt = new ListenableOnOffRead.Impl(false);
+
+        try (Pi4jLr11xxIo io = new Pi4jLr11xxIo(null, reset,
+                new ListenableOnOffRead.Impl(false), interrupt)) {
+            interrupt.setState(true);
+
+            io.reset();
+
+            assertTrue(reset.isOn(), "the radio has to be let out of reset again");
+            assertFalse(io.awaitInterrupt(Duration.ofMillis(20)),
+                    "the edge from before the reset would read as a packet of nothing");
+        }
     }
 }

--- a/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Pi4jLr11xxIoTest.java
+++ b/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/Pi4jLr11xxIoTest.java
@@ -1,0 +1,64 @@
+package com.pi4j.drivers.radio.lora.lr11xx;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pi4j.io.gpio.digital.DigitalInput;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * The one part of the Pi4J binding that can be checked without a radio, and the
+ * part most likely to save somebody an evening.
+ *
+ * <p>A debounced input is not a slower driver, it is a driver that receives
+ * nothing: Pi4J passes the value to the kernel, which then reports no event at all
+ * for a pulse shorter than the window. This radio's pulses are far shorter than the
+ * ten milliseconds Pi4J defaults to.
+ */
+class Pi4jLr11xxIoTest {
+
+    /** Zero is the only correct answer for a line driven by a chip. */
+    @Test
+    void anUndebouncedInputIsAccepted() {
+        assertDoesNotThrow(() -> Pi4jLr11xxIo.requireUndebounced("interrupt", 0L));
+    }
+
+    /**
+     * Pi4J's default is the case that matters. An input built without a word about
+     * debouncing arrives with 10 000 µs, so this is what a caller who never thought
+     * about it will hit — and it has to fail loudly rather than at the antenna.
+     */
+    @Test
+    void pi4jsOwnDefaultIsRefused() {
+        IllegalArgumentException thrown = assertThrows(IllegalArgumentException.class,
+                () -> Pi4jLr11xxIo.requireUndebounced("interrupt",
+                        DigitalInput.DEFAULT_DEBOUNCE));
+
+        assertTrue(thrown.getMessage().contains("interrupt"),
+                "the message has to say which line, since two are passed in");
+        assertTrue(thrown.getMessage().contains(".debounce(0L)"),
+                "and it has to say what to do about it");
+    }
+
+    /**
+     * Any non-zero value, not just the default. A small debounce might look harmless
+     * and still be longer than the pulse: the driver clears the interrupt as fast as
+     * the bus allows, and it has no way to know how fast that is on someone else's
+     * wiring.
+     */
+    @Test
+    void anyDebounceAtAllIsRefused() {
+        assertThrows(IllegalArgumentException.class,
+                () -> Pi4jLr11xxIo.requireUndebounced("busy", 1L));
+        assertThrows(IllegalArgumentException.class,
+                () -> Pi4jLr11xxIo.requireUndebounced("busy", 500L));
+    }
+
+    /** A provider that reports nothing has not debounced anything. */
+    @Test
+    void anAbsentValueIsNotADebounce() {
+        assertDoesNotThrow(() -> Pi4jLr11xxIo.requireUndebounced("interrupt", null));
+    }
+}

--- a/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/RecordingIo.java
+++ b/src/test/java/com/pi4j/drivers/radio/lora/lr11xx/RecordingIo.java
@@ -1,0 +1,141 @@
+package com.pi4j.drivers.radio.lora.lr11xx;
+
+import java.time.Duration;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Deque;
+import java.util.HexFormat;
+import java.util.List;
+
+/**
+ * A radio made of a list. It records every byte written and plays back answers
+ * queued in advance, which is enough to check every command this driver builds
+ * without any hardware.
+ *
+ * <p>The answers are queued <em>without</em> the status byte the radio sends
+ * before a response: this adds it, so that a test reads like the datasheet rather
+ * than like the wire.
+ */
+class RecordingIo implements Lr11xxIo {
+
+    /** An answer, and whether the radio puts a status byte in front of it. */
+    private record Answer(byte[] bytes, boolean statusPrefixed) {
+    }
+
+    private final List<byte[]> written = new ArrayList<>();
+    private final Deque<Answer> answers = new ArrayDeque<>();
+
+    /**
+     * What the radio says once the queued answers run out, or null to insist that
+     * every read was expected. A receiver waiting for a packet reads the flags
+     * for as long as it waits, and there is no useful number of times to queue.
+     */
+    private Answer whenNothingLeft;
+
+    int resets;
+    int readyWaits;
+    boolean interruptFires = true;
+    boolean closed;
+
+    /**
+     * Queues the answer to a command, status byte excluded — the radio sends one
+     * in front of every response and this adds it, so that a test reads like the
+     * datasheet rather than like the wire.
+     */
+    void willAnswer(int... bytes) {
+        answers.addLast(new Answer(toBytes(bytes), true));
+    }
+
+    /**
+     * Queues the bytes of a direct read, which has no status byte in front of it
+     * because its first byte is one. GetStatus is read this way.
+     */
+    void willAnswerDirectly(int... bytes) {
+        answers.addLast(new Answer(toBytes(bytes), false));
+    }
+
+    /** What a direct read returns from then on, however many times it happens. */
+    void willKeepAnsweringDirectly(int... bytes) {
+        whenNothingLeft = new Answer(toBytes(bytes), false);
+    }
+
+    /** The same for a command's answer, for a radio that never changes its mind. */
+    void willKeepAnswering(int... bytes) {
+        whenNothingLeft = new Answer(toBytes(bytes), true);
+    }
+
+    private static byte[] toBytes(int... values) {
+        byte[] bytes = new byte[values.length];
+        for (int i = 0; i < values.length; i++) {
+            bytes[i] = (byte) values[i];
+        }
+        return bytes;
+    }
+
+    @Override
+    public void writeBytes(byte[] bytes) {
+        written.add(bytes.clone());
+    }
+
+    @Override
+    public void readBytes(byte[] into) {
+        Answer answer = answers.pollFirst();
+        if (answer == null) {
+            answer = whenNothingLeft;
+        }
+        if (answer == null) {
+            throw new AssertionError("The driver read an answer that no test queued");
+        }
+        int offset = answer.statusPrefixed() ? 1 : 0;
+        if (offset == 1) {
+            into[0] = 0x00;
+        }
+        System.arraycopy(answer.bytes(), 0, into, offset,
+                Math.min(answer.bytes().length, into.length - offset));
+    }
+
+    @Override
+    public void awaitReady(Duration timeout) {
+        readyWaits++;
+    }
+
+    @Override
+    public void reset() {
+        resets++;
+    }
+
+    @Override
+    public boolean awaitInterrupt(Duration timeout) {
+        return interruptFires;
+    }
+
+    @Override
+    public void close() {
+        closed = true;
+    }
+
+    // ------------------------------------------------------------------
+
+    /** Every transaction, as hex, oldest first. */
+    List<String> transactions() {
+        return written.stream().map(HexFormat.of().withUpperCase()::formatHex).toList();
+    }
+
+    /** Whether a transaction with exactly these bytes was written. */
+    boolean wrote(String hex) {
+        return transactions().contains(hex);
+    }
+
+    /** The first transaction that begins with this opcode, as hex. */
+    String transactionFor(String opcodeHex) {
+        return transactions().stream()
+                .filter(transaction -> transaction.startsWith(opcodeHex))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError(
+                        "No command " + opcodeHex + " among " + transactions()));
+    }
+
+    int transactionCount() {
+        return written.size();
+    }
+}


### PR DESCRIPTION
Covers the LR1121, LR1120 and LR1110, which share a command set. Written against SWDR001, Semtech's own C driver, rather than off a datasheet: where the two would disagree, the C driver is what the hardware has actually been tested with. Verified on a Waveshare Core1121 receiving packets from a Pico.

    try (Lr1121Driver radio = new Lr1121Driver(pi4j, 0, SpiChipSelect.CS_0,
            22 /* reset */, 24 /* busy */, 23 /* DIO9 */)) {
        radio.configure(Lr1121Driver.BoardConfig.core1121());
        radio.configureLora(868_000_000L, Lr1121Driver.LoraSettings.defaults());
        radio.receive(settings, Duration.ofSeconds(10)).ifPresent(...);
    }

The constructor asks for what only the person who wired the board can know, and sets what belongs to the chip: SPI mode 0, a reset line high from the moment it is claimed, and inputs with no debounce. Two of those three are wrong by default, and both fail silently.

The debounce one is worth stating plainly, because it cost an evening. Pi4J defaults DigitalInput debouncing to 10 000 us and an unset config materialises the default, so an input built without a word about debouncing arrives debounced. That value is not a filter in Java: it is passed to the kernel as GPIO_V2_LINE_ATTR_ID_DEBOUNCE, and the kernel then reports no event at all for a pulse shorter than the window. This radio holds its interrupt line high only until the driver clears the interrupt, which is three short reads — an order of magnitude inside that window. So the default costs every reception, and the symptom is silence, which is also what a wrong spreading factor, a wrong sync word and a missing antenna look like. The constructor that builds the inputs avoids it; the one that accepts them refuses a debounced line rather than warning, since neither of these lines is attached to anything that bounces.

Lr11xxIo is what the driver needs from the wires, and it is device specific and local by design. It keeps command building testable without hardware — the thirty tests here check every command against the bytes SWDR001 sends, with a recording standing in for the radio — and it leaves room for the same chip reached some other way, such as a USB adapter.

Interrupts arrive as Pi4J listener callbacks and the driver needs to block, so a semaphore bridges the two. A semaphore rather than a rendezvous: receive() puts the radio into receive mode and only then starts waiting, so an edge that lands in between has to be remembered rather than dropped, which is what the kernel does for free with the events it queues on the line's file descriptor.

The hardware checks are gated on a system property rather than @Disabled, which is a small departure from the convention here and has a reason: a radio cannot hear itself, so this driver can only be proved with two devices at once, and @Disabled would mean the same source edit on both. They also have a main, so the usual case — two small computers driven over SSH from a third — needs a JRE and an rsync rather than a checkout and a warm repository on each device.

    mvn test -Dtest=Lr1121DriverHardwareTest -Dlr11xx.role=check      # one radio
    mvn test -Dtest=Lr1121DriverHardwareTest -Dlr11xx.role=receive    # on one
    mvn test -Dtest=Lr1121DriverHardwareTest -Dlr11xx.role=transmit   # on the other