### PR TITLE
Add a generic SSD1780 ePaper driver

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -71,7 +71,9 @@ public class GraphicsDisplay {
             displayWidth = driver.getDisplayInfo().getHeight();
             displayHeight = driver.getDisplayInfo().getWidth();
         }
-        displayBuffer = new int[displayWidth * displayHeight];
+        // +7 buffer for granularity vs. width mismatches, e.g. display width 122 with granularity 8 will just
+        // read over the end instead of more complex handing for this case.
+        displayBuffer = new int[displayWidth * displayHeight + 7];
         drivers.add(new DriverEntry(0, 0, driver, rotation, mirror));
     }
 
@@ -82,7 +84,7 @@ public class GraphicsDisplay {
     public GraphicsDisplay(int displayWidth, int displayHeight) {
         this.displayWidth = displayWidth;
         this.displayHeight = displayHeight;
-        displayBuffer = new int[displayWidth * displayHeight];
+        displayBuffer = new int[displayWidth * displayHeight + 7]; // +7 see comment in other ctor.
     }
 
 
@@ -325,7 +327,7 @@ public class GraphicsDisplay {
             // We limit the transfer size to 4000 bytes, but at least a full row of pixels
             this.transferBuffer = new byte[Math.min(
                     Math.max(driver.getTransferLimit(), (bitsPerRow + 7) / 8),
-                    (bitsPerRow * driver.getDisplayInfo().getHeight() + 7) / 8)];
+                    ((bitsPerRow + 7) / 8 * driver.getDisplayInfo().getHeight()))];
         }
 
         private void transferBuffer(int xMin, int yMin, int xMax, int yMax) {

--- a/src/main/java/com/pi4j/drivers/display/graphics/ssd1677/Ssd1677Driver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/ssd1677/Ssd1677Driver.java
@@ -58,7 +58,7 @@ public abstract class Ssd1677Driver implements GraphicsDisplayDriver {
     @Override
     public void close() {
         sendCommand(Command.DEEP_SLEEP_MODE, 0x03); //enter deep sleep
-        delay.setMillis(100);
+        delay.setMillis(100).materialize();
     }
 
     @Override

--- a/src/main/java/com/pi4j/drivers/display/graphics/ssd1680/Command.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/ssd1680/Command.java
@@ -1,0 +1,48 @@
+package com.pi4j.drivers.display.graphics.ssd1680;
+
+public enum Command {
+    /*
+     * Sets the number of gate outputs (rows) and scanning direction.
+     * Requires 3 bytes: rows-1 low, rows-1 high, scanning mode.
+     */
+    DRIVER_OUTPUT_CONTROL(0x01, 3),
+
+    /** 1 byte; 0x0 = normal mode; 0x3 = deep sleep */
+    DEEP_SLEEP_MODE(0x10, 1),
+
+    /** Address counter direction; Bit 0: x (0:-; 1:+) Bit 1: y (0:-; 1:+), Bit 2: primary direction 0=x; 1: y) */
+    DATA_ENTRY_MODE_SETTING(0x11, 1),
+
+    SW_RESET(0x12, 0),
+
+    /** 0x80: Internal temperature sensor; 0x48: External */
+    TEMPERATURE_SENSOR_CONTROL(0x18, 1),
+
+    MASTER_ACTIVATION(0x20, 0),
+    /**
+     * Controls which ram sources are used for a display update.
+     * 00: normal; 0x40 ignore red.
+     */
+    DISPLAY_UPDATE_CONTROL_1(0x21, 2),
+
+    DISPLAY_UPDATE_CONTROL_2(0x22, 1),
+
+    WRITE_RAM(0x24, -1),
+
+    BORDER_WAVEFORM_CONTROL(0x3C, 1),
+
+    SET_RAM_X_ADDRESS_RANGE(0x44, 2),
+    SET_RAM_Y_ADDRESS_RANGE(0x45, 4),
+
+    SET_RAM_X_ADDRESS(0x4E, 1),
+    SET_RAM_Y_ADDRESS(0x4F, 2),
+    ;
+
+    final int code;
+    final int dataCount;
+
+    Command(int code, int dataCount) {
+        this.code = code;
+        this.dataCount = dataCount;
+    }
+}

--- a/src/main/java/com/pi4j/drivers/display/graphics/ssd1680/Ssd1680Driver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/ssd1680/Ssd1680Driver.java
@@ -1,0 +1,143 @@
+package com.pi4j.drivers.display.graphics.ssd1680;
+
+import com.pi4j.drivers.display.graphics.GraphicsDisplay;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayDescriptor;
+import com.pi4j.drivers.display.graphics.GraphicsDisplayDriver;
+import com.pi4j.drivers.display.graphics.PixelFormat;
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.spi.Spi;
+import com.pi4j.util.Delay;
+
+public abstract class Ssd1680Driver implements GraphicsDisplayDriver {
+    private final Spi spi;
+    private final DigitalOutput rst;
+    private final DigitalOutput dc;
+    private final DigitalInput busy;
+    private final Delay delay = new Delay();
+    private final GraphicsDisplayDescriptor descriptor;
+    private byte[] transferBuffer = new byte[64];
+
+
+    protected Ssd1680Driver(
+            Spi spi,
+            DigitalOutput dc,
+            DigitalOutput rst,
+            DigitalInput busy,
+            int width,
+            int height) {
+        this.spi = spi;
+        this.dc = dc;
+        this.rst = rst;
+        this.busy = busy;
+        this.descriptor = new GraphicsDisplayDescriptor(
+                width,
+                height,
+                PixelFormat.MONOCHROME,
+                8, GraphicsDisplay.Rotation.ROTATE_0);
+
+        reset();
+        sendCommand(Command.SW_RESET);
+        sendCommand(Command.DRIVER_OUTPUT_CONTROL, 0xf9, 0, 0);
+        sendCommand(Command.DATA_ENTRY_MODE_SETTING, 0x03);
+        sendCommand(Command.DISPLAY_UPDATE_CONTROL_1, 0, 0x80);
+        sendCommand(Command.DISPLAY_UPDATE_CONTROL_2, 0xf7);
+        sendCommand(Command.TEMPERATURE_SENSOR_CONTROL, 0x80);
+    }
+
+
+    // Public API ------------------------------------------------------------------------------------------------------
+
+    @Override
+    public void close() {
+        sendCommand(Command.DEEP_SLEEP_MODE, 0x03); //enter deep sleep
+        delay.setMillis(100).materialize();
+    }
+
+    @Override
+    public int getTransferLimit() {
+        return Integer.MAX_VALUE;
+    }
+
+    @Override
+    public GraphicsDisplayDescriptor getDisplayInfo() {
+        return descriptor;
+    }
+
+    @Override
+    public boolean isBusy() {
+        return busy.isOn();
+    }
+
+    public void setPixels(int x, int y, int width, int height, byte[] data) {
+
+        setWindow(x, y, x + width - 1, y + height - 1);
+
+        int byteCount = (width * height + 7) / 8;
+
+        sendCommand(Command.WRITE_RAM);
+        sendData(data, 0, byteCount);
+        sendCommand(Command.MASTER_ACTIVATION);
+    }
+
+    // Helpers -------------------------------------------------------------------------------------------------
+
+    protected void reset() {
+        rst.setState(1);
+        delay.setMillis(100).materialize();
+        rst.setState(0);
+        delay.setMillis(20).materialize();
+        rst.setState(1);
+        delay.setMillis(200);  // Was 100, but following commands had extra 100
+    }
+
+    protected void sendCommand(Command command, int... data) {
+        blockWhileBusy();
+        delay.materialize();
+
+        if (command.dataCount != -1 && command.dataCount != data.length) {
+            throw new IllegalArgumentException("Expected " + command.dataCount + " data bytes for " + command + "; got: " + data.length);
+        }
+
+        dc.setState(0);
+        spi.write(command.code);
+        sendData(data);
+    }
+
+    protected void sendData(int... data) {
+        if (data.length > transferBuffer.length) {
+            transferBuffer = new byte[data.length];
+        }
+        for (int i = 0; i < data.length; i++) {
+            transferBuffer[i] = (byte) data[i];
+        }
+        sendData(transferBuffer, 0, data.length);
+    }
+
+    protected void sendData(byte[] data, int offset, int length) {
+        dc.setState(1);
+        int written = 0;
+        while (written < length) {
+            int count = Math.min(length - written, 4000);
+            spi.write(data, offset + written, count);
+            written += count;
+        }
+    }
+
+    private void blockWhileBusy() {
+        delay.materialize();
+        while(isBusy()) {
+            delay.setMillis(20).materialize();
+        }
+        delay.setMillis(20);
+    }
+
+    /** Note that x-coordinates have to be a multiple of 8 */
+    protected void setWindow(int xStart, int yStart, int xEnd, int yEnd) {
+        sendCommand(Command.SET_RAM_X_ADDRESS_RANGE,(xStart >>> 3) & 0xFF, (xEnd >>> 3) & 0xFF);
+        sendCommand(Command.SET_RAM_Y_ADDRESS_RANGE, yStart & 0xFF, (yStart>>8) & 0x03, yEnd & 0xFF, (yEnd>>8) & 0x03);
+        sendCommand(Command.SET_RAM_X_ADDRESS, (xStart >> 3) & 0xFF);
+        sendCommand(Command.SET_RAM_Y_ADDRESS, yStart & 0xff, (yStart >> 8) & 0x03);
+    }
+
+}

--- a/src/main/java/com/pi4j/drivers/display/graphics/ssd1680/Waveshare2in12V4.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/ssd1680/Waveshare2in12V4.java
@@ -1,0 +1,15 @@
+package com.pi4j.drivers.display.graphics.ssd1680;
+
+import com.pi4j.io.gpio.digital.DigitalInput;
+import com.pi4j.io.gpio.digital.DigitalOutput;
+import com.pi4j.io.spi.Spi;
+
+public class Waveshare2in12V4 extends Ssd1680Driver {
+    public Waveshare2in12V4(
+            Spi spi,
+            DigitalOutput dc,
+            DigitalOutput rst,
+            DigitalInput busy) {
+        super(spi, dc, rst, busy, 122, 250);
+    }
+}


### PR DESCRIPTION
Including a concrete implementation for the Waveshare 2.13inch ePaper hat V4

Also adjust GraphicsDisplay to support display widths that are not a multiple of the display data granularity (why would anybody design a display with a width of 122 pixel instead of 120 or 128??) and fix a minor bug in the ssd1677 driver

