### PR TITLE
Address #163: Clarify display placement limitations

### DIFF
--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -73,7 +73,7 @@ public class GraphicsDisplay {
         }
         // +7 buffer for granularity vs. width mismatches, e.g. display width 122 with granularity 8 will just
         // read over the end instead of more complex handing for this case.
-        displayBuffer = new int[displayWidth * displayHeight + 7];
+        displayBuffer = new int[displayWidth * displayHeight + 7000];
         drivers.add(new DriverEntry(0, 0, driver, rotation, mirror));
     }
 
@@ -364,75 +364,83 @@ public class GraphicsDisplay {
             // Translate the column scan directions into coordinate ranges and strides for transfer.
             // The compiler can't figure out that all will be set due to direction interdependencies,
             // so we have to initialize the values.
-            int sourceX = 0;
-            int sourceY = 0;
-            int transferXMin = 0;
-            int transferXMax = 0;
-            int transferYMin = 0;
-            int transferYMax = 0;
+
+            // Transfer starting point in the source buffer
+            int sourceX0 = 0;
+            int sourceY0 = 0;
+
+            // Movement in the source buffer when processing a target row
             int sourceStrideX = 0;
+            // Movement in the source buffer when going to the next target row
             int sourceStrideY = 0;
 
+            // Destination in driver coordinates.
+            int destinationXMin = 0;
+            int destinationXMax = 0;
+            int destinationYMin = 0;
+            int destinationYMax = 0;
+
+            // Note that the two switches set sourceX0 or sourceY0, depending on the rotation.
             switch (columnScanDirection) {
                 case LEFT_TO_RIGHT -> {
-                    sourceX = xMin;
-                    transferXMin = xMin - x0;
-                    transferXMax = xMax - x0;
+                    sourceX0 = xMin;
                     sourceStrideX = 1;
+                    destinationXMin = xMin - x0;
+                    destinationXMax = xMax - x0;
                 }
                 case RIGHT_TO_LEFT -> {
-                    sourceX = xMax - 1;
-                    transferXMin = displayWidth - xMax - x0;
-                    transferXMax = displayWidth - xMin - x0;
+                    sourceX0 = xMax - 1;
                     sourceStrideX = -1;
+                    destinationXMin = xMin - x0;
+                    destinationXMax = xMax - x0;
                 }
                 case TOP_DOWN -> {
-                    sourceY = yMin;
-                    transferXMin = yMin - y0;
-                    transferXMax = yMax - y0;
+                    sourceY0 = yMin;
                     sourceStrideX = displayWidth;
+                    destinationXMin = yMin - y0;
+                    destinationXMax = yMax - y0;
                 }
                 case BOTTOM_UP -> {
-                    sourceY = yMax - 1;
-                    transferXMin = displayHeight - yMax - y0;
-                    transferXMax = displayHeight - yMin - y0;
+                    sourceY0 = yMax - 1;
                     sourceStrideX = -displayWidth;
+                    destinationXMin = yMin - y0;
+                    destinationXMax = yMax - y0;
                 }
             }
             switch (rowScanDirection) {
                 case TOP_DOWN -> {
-                    sourceY = yMin;
-                    transferYMin = yMin - y0;
-                    transferYMax = yMax - y0;
+                    sourceY0 = yMin;
                     sourceStrideY = displayWidth;
+                    destinationYMin = yMin - y0;
+                    destinationYMax = yMax - y0;
                 }
                 case BOTTOM_UP -> {
-                    sourceY = yMax - 1;
-                    transferYMin = displayHeight - yMax - y0;
-                    transferYMax = displayHeight - yMin - y0;
+                    sourceY0 = yMax - 1;
                     sourceStrideY = -displayWidth;
+                    destinationYMin = yMin - y0;
+                    destinationYMax = yMax - y0;
                 }
                 case LEFT_TO_RIGHT -> {
-                    sourceX = xMin;
-                    transferYMin = yMin - y0;
-                    transferYMax = yMax - y0;
+                    sourceX0 = xMin;
                     sourceStrideY = 1;
+                    destinationYMin = xMin - x0;
+                    destinationYMax = xMax - x0;
                 }
                 case RIGHT_TO_LEFT -> {
-                    sourceX = xMax - 1;
-                    transferYMin = displayWidth - xMax - x0;
-                    transferYMax = displayWidth - xMin - x0;
+                    sourceX0 = xMax - 1;
                     sourceStrideY = -1;
+                    destinationYMin = xMin - x0;
+                    destinationYMax = xMax - x0;
                 }
             }
             transferBuffer(
-                    pixelAddress(sourceX, sourceY),
+                    pixelAddress(sourceX0, sourceY0),
                     sourceStrideX,
                     sourceStrideY,
-                    transferXMin,
-                    transferYMin,
-                    transferXMax,
-                    transferYMax);
+                    destinationXMin,
+                    destinationYMin,
+                    destinationXMax,
+                    destinationYMax);
         }
 
         /** Transfers the given display buffer area to the display driver */
@@ -440,21 +448,21 @@ public class GraphicsDisplay {
             GraphicsDisplayDescriptor displayInfo = driver.getDisplayInfo();
 
             // Bail out if the changed area is outside the area governed by this device.
-            if (xMax <= 0 || yMax <= 0 || xMin >= displayInfo.getWidth() || yMin >= displayInfo.getHeight()) {
+            if (xMax <= 0 || yMax <= 0
+                    || xMin >= displayInfo.getWidth() || yMin >= displayInfo.getHeight()
+                    || xMax <= xMin || yMax <= yMin) {
                 return;
             }
 
             // Restrict coordinates to the display size.
             if (xMin < 0) {
-                sourceAddress -= xMax * sourceStrideX;
+                sourceAddress -= xMin * sourceStrideX;
                 xMin = 0;
             }
             if (yMin < 0) {
                 sourceAddress -= yMin * sourceStrideY;
                 yMin = 0;
             }
-            xMax = Math.min(displayInfo.getWidth(), xMax);
-            yMax = Math.min(displayInfo.getHeight(), yMax);
 
             // Make sure to match device x-alignment constraints.
             int xGranularity = driver.getDisplayInfo().getXGranularity();
@@ -463,13 +471,22 @@ public class GraphicsDisplay {
                 sourceAddress -= remainder * sourceStrideX;
                 xMin -= remainder;
             }
+
             xMax = ((xMax + xGranularity - 1) / xGranularity) * xGranularity;
+            xMax = Math.min(displayInfo.getWidth(), xMax);
+            yMax = Math.min(displayInfo.getHeight(), yMax);
 
             int width = xMax - xMin;
             int height = yMax - yMin;
 
+            // Yes, there are displays where the width doesn't match the granularity... ლ(ಠ益ಠლ)
+            remainder = width % xGranularity;
+            if (remainder != 0) {
+                remainder = xGranularity - remainder;
+            }
+
             PixelFormat pixelFormat = driver.getDisplayInfo().getPixelFormat();
-            int bitsPerRow = width * pixelFormat.getBitCount();
+            int bitsPerRow = (width + remainder) * pixelFormat.getBitCount();
             int bitOffset = 0;
 
             synchronized (lock) { // display / transfer buffer access
@@ -481,10 +498,15 @@ public class GraphicsDisplay {
                             transferBuffer,
                             bitOffset,
                             width);
+
+                    bitOffset += remainder * pixelFormat.getBitCount();
                     sourceAddress += sourceStrideY;
+
                     // Transfer if the last row is reached or the next row would overflow the buffer.
                     if (i == height - 1 || bitOffset + bitsPerRow > transferBuffer.length * 8) {
                         int rows = bitOffset / bitsPerRow;
+                        // We send `width` here (instead of `width + remainder`) as this then can still be adjusted
+                        // in the driver as needed -- otherwise the information would be lost.
                         driver.setPixels(xMin, yMin + i + 1 - rows, width, rows, transferBuffer);
                         bitOffset = 0;
                     }

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -82,7 +82,7 @@ public class GraphicsDisplay {
     public GraphicsDisplay(int displayWidth, int displayHeight) {
         this.displayWidth = displayWidth;
         this.displayHeight = displayHeight;
-        displayBuffer = new int[displayWidth * displayHeight]; 
+        displayBuffer = new int[displayWidth * displayHeight];
     }
 
 
@@ -102,7 +102,13 @@ public class GraphicsDisplay {
      */
     public void attachDriver(int x0, int y0, GraphicsDisplayDriver driver, Rotation rotation, Mirror mirror) {
         synchronized (lock) {
-            drivers.add(new DriverEntry(x0, y0, driver, rotation.minus(driver.getDisplayInfo().getImplicitRotation()), mirror));
+            DriverEntry entry = new DriverEntry(x0, y0, driver, rotation.minus(driver.getDisplayInfo().getImplicitRotation()), mirror);
+            if (entry.driver.getDisplayInfo().getXGranularity() != 1 &&
+                    (x0 < 0 || y0 < 0 || x0 + entry.getSourceWidth() > displayWidth || y0 + entry.getSourceHeight() > displayHeight)) {
+                throw new IllegalArgumentException(
+                        "Drivers requiring a position granularity cannot be placed (partially) outside the display");
+            }
+            drivers.add(entry);
             markModified(0, 0, displayWidth, displayHeight);
         }
     }
@@ -327,6 +333,19 @@ public class GraphicsDisplay {
                     Math.max(driver.getTransferLimit(), (bitsPerRow + 7) / 8),
                     ((bitsPerRow + 7) / 8 * driver.getDisplayInfo().getHeight()))];
         }
+
+        int getSourceWidth() {
+            return rotation == Rotation.ROTATE_90 || rotation == Rotation.ROTATE_270
+                    ? driver.getDisplayInfo().getHeight()
+                    : driver.getDisplayInfo().getWidth();
+        }
+
+        int getSourceHeight() {
+            return rotation == Rotation.ROTATE_90 || rotation == Rotation.ROTATE_270
+                    ? driver.getDisplayInfo().getWidth()
+                    : driver.getDisplayInfo().getHeight();
+        }
+
 
         private void transferBuffer(int xMin, int yMin, int xMax, int yMax) {
             ScanDirection columnScanDirection;

--- a/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/GraphicsDisplay.java
@@ -71,9 +71,7 @@ public class GraphicsDisplay {
             displayWidth = driver.getDisplayInfo().getHeight();
             displayHeight = driver.getDisplayInfo().getWidth();
         }
-        // +7 buffer for granularity vs. width mismatches, e.g. display width 122 with granularity 8 will just
-        // read over the end instead of more complex handing for this case.
-        displayBuffer = new int[displayWidth * displayHeight + 7000];
+        displayBuffer = new int[displayWidth * displayHeight];
         drivers.add(new DriverEntry(0, 0, driver, rotation, mirror));
     }
 
@@ -84,7 +82,7 @@ public class GraphicsDisplay {
     public GraphicsDisplay(int displayWidth, int displayHeight) {
         this.displayWidth = displayWidth;
         this.displayHeight = displayHeight;
-        displayBuffer = new int[displayWidth * displayHeight + 7]; // +7 see comment in other ctor.
+        displayBuffer = new int[displayWidth * displayHeight]; 
     }
 
 

--- a/src/main/java/com/pi4j/drivers/display/graphics/PixelFormat.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/PixelFormat.java
@@ -71,14 +71,12 @@ public enum PixelFormat {
      *
      * @param value
      *            The value to write.
-     * @param count
-     *            The number of bits (up to 24).
      * @param buffer
      *            The buffer to write the bits to
      * @param bitOffset
      *            The bit offset in the buffer
      */
-    private void writeBits(int value, int count, byte[] buffer, int bitOffset) {
+    private void writeBits(int value, byte[] buffer, int bitOffset) {
         int byteOffset = bitOffset / 8;
 
         // We need to special-case RGB_565_LE here anyway (the expected bytes are gggBbbbb, RrrrrGgg),
@@ -99,9 +97,9 @@ public enum PixelFormat {
             }
             default -> {
                 bitOffset %= 8;
-                int mask = ((1 << count) - 1) << (32 - count - bitOffset);
+                int mask = ((1 << bitCount) - 1) << (32 - bitCount - bitOffset);
 
-                value <<= (32 - count - bitOffset);
+                value <<= (32 - bitCount - bitOffset);
                 while (mask != 0) {
                     buffer[byteOffset] = (byte) ((buffer[byteOffset] & ~(mask >> 24)) | (value >> 24));
                     byteOffset++;
@@ -134,9 +132,8 @@ public enum PixelFormat {
      * number of bits written.
      */
     int writeRgb(int rgb, byte[] buffer, int bitOffset) {
-        int count = redBitCount + greenBitCount + blueBitCount;
-        writeBits(fromRgb(rgb), count, buffer, bitOffset);
-        return count;
+        writeBits(fromRgb(rgb), buffer, bitOffset);
+        return bitCount;
     }
 
     /**
@@ -180,7 +177,8 @@ public enum PixelFormat {
      int writeRgb(int[] srcRgb, int srcOffset, int srcStride, byte[] dst, int dstBitOffset, int pixelCount) {
         int bitsWritten = 0;
         for (int i = 0; i < pixelCount; i++) {
-            bitsWritten += writeRgb(srcRgb[srcOffset], dst, dstBitOffset + bitsWritten);
+            writeRgb(srcRgb[srcOffset], dst, dstBitOffset + bitsWritten);
+            bitsWritten += bitCount;
             srcOffset += srcStride;
         }
         return bitsWritten;
@@ -192,9 +190,8 @@ public enum PixelFormat {
     int fillRgb(byte[] dst, int dstBitOffset, int pixelCount, int rgb) {
         int bitsWritten = 0;
         int nativeColor = fromRgb(rgb);
-        int bitCount = getBitCount();
         for (int i = 0; i < pixelCount; i++) {
-            writeBits(nativeColor, bitCount, dst, dstBitOffset + bitsWritten);
+            writeBits(nativeColor, dst, dstBitOffset + bitsWritten);
             bitsWritten += bitCount;
         }
         return bitsWritten;

--- a/src/main/java/com/pi4j/drivers/display/graphics/ssd1680/Ssd1680Driver.java
+++ b/src/main/java/com/pi4j/drivers/display/graphics/ssd1680/Ssd1680Driver.java
@@ -70,11 +70,11 @@ public abstract class Ssd1680Driver implements GraphicsDisplayDriver {
     }
 
     public void setPixels(int x, int y, int width, int height, byte[] data) {
-
+        if (width % 8 != 0) {
+            width += 8 - (width % 8);
+        }
         setWindow(x, y, x + width - 1, y + height - 1);
-
         int byteCount = (width * height + 7) / 8;
-
         sendCommand(Command.WRITE_RAM);
         sendData(data, 0, byteCount);
         sendCommand(Command.MASTER_ACTIVATION);

--- a/src/test/java/com/pi4j/drivers/display/graphics/OffsetDisplayTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/OffsetDisplayTest.java
@@ -14,6 +14,7 @@ public class OffsetDisplayTest {
 
         GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
+        display.setTransferDelayMillis(0);
 	display.attachDriver( 0, 0, driver, Rotation.ROTATE_0 );
     }
 
@@ -22,6 +23,7 @@ public class OffsetDisplayTest {
 
         GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
+        display.setTransferDelayMillis(0);
         display.attachDriver( -10, -10, driver, Rotation.ROTATE_0 );
     }
 
@@ -30,6 +32,7 @@ public class OffsetDisplayTest {
 
         GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
+        display.setTransferDelayMillis(0);
         display.attachDriver( 10, 10, driver, Rotation.ROTATE_0 );
     }
 
@@ -38,6 +41,7 @@ public class OffsetDisplayTest {
 
         GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
+        display.setTransferDelayMillis(0);
         display.attachDriver( 1, 0, driver, Rotation.ROTATE_0 );
     }
 
@@ -46,6 +50,7 @@ public class OffsetDisplayTest {
 
         GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
+        display.setTransferDelayMillis(0);
         display.attachDriver( 0, 1, driver, Rotation.ROTATE_0 );
     }
 }

--- a/src/test/java/com/pi4j/drivers/display/graphics/OffsetDisplayTest.java
+++ b/src/test/java/com/pi4j/drivers/display/graphics/OffsetDisplayTest.java
@@ -6,49 +6,97 @@ import com.pi4j.drivers.display.graphics.GraphicsDisplay.Rotation;
 
 import org.junit.jupiter.api.Test;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.fail;
 
 public class OffsetDisplayTest {
 
     @Test
     public void testBaseline() {
-
         GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
         display.setTransferDelayMillis(0);
-	display.attachDriver( 0, 0, driver, Rotation.ROTATE_0 );
+    	display.attachDriver(0, 0, driver, Rotation.ROTATE_0);
     }
 
     @Test
-    public void testNegative() {
-
+    public void testNegative444() {
         GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
+        GraphicsDisplay display = new GraphicsDisplay(100,100);
+        display.setTransferDelayMillis(0);
+        try {
+            display.attachDriver(-10, -10, driver, Rotation.ROTATE_0);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testPositive444() {
+        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
+        GraphicsDisplay display = new GraphicsDisplay(100,100);
+        display.setTransferDelayMillis(0);
+        try {
+            display.attachDriver(10, 10, driver, Rotation.ROTATE_0);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testX444() {
+        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
+        GraphicsDisplay display = new GraphicsDisplay(100,100);
+        display.setTransferDelayMillis(0);
+        try {
+            display.attachDriver( 1, 0, driver, Rotation.ROTATE_0 );
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testY444() {
+        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
+        GraphicsDisplay display = new GraphicsDisplay(100,100);
+        display.setTransferDelayMillis(0);
+        try {
+            display.attachDriver(0, 1, driver, Rotation.ROTATE_0);
+            fail();
+        } catch (IllegalArgumentException e) {
+            // Expected
+        }
+    }
+
+    @Test
+    public void testNegative888() {
+        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_888);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
         display.setTransferDelayMillis(0);
         display.attachDriver( -10, -10, driver, Rotation.ROTATE_0 );
     }
 
     @Test
-    public void testPositive() {
-
-        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
+    public void testPositive888() {
+        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_888);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
         display.setTransferDelayMillis(0);
         display.attachDriver( 10, 10, driver, Rotation.ROTATE_0 );
     }
 
     @Test
-    public void testX() {
-
-        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
+    public void testX888() {
+        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_888);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
         display.setTransferDelayMillis(0);
         display.attachDriver( 1, 0, driver, Rotation.ROTATE_0 );
     }
 
     @Test
-    public void testY() {
-
-        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_444);
+    public void testY888() {
+        GraphicsDisplayDriver driver = new FakeGraphicsDisplayDriver(100, 100, PixelFormat.RGB_888);
         GraphicsDisplay display = new GraphicsDisplay(100,100);
         display.setTransferDelayMillis(0);
         display.attachDriver( 0, 1, driver, Rotation.ROTATE_0 );


### PR DESCRIPTION
One cause for the issue was an x/y mixup in xMin adjustment inside transfer(), but there are additional problems when placing drivers with xGranulatity != 1 outside the "logical" display

- Drivers with an xGranularity != 1 might require additional pixels to be sent, e.g if the granularity is 2 and the display position is odd, the driver might need a "filler" pixel outside of update area bounds, which then can also fall outside of the screen.
- To avoid a lot of additional complexity, placing drivers with xGranularity != 1 outside the logical display dimensions now fails quicky with an explanatory exception. 
- Test have been adjusted to illustrate both cases.
- If needed, we could potentially reduce the limitations (coordinates and width or height must be multiple of xGranularity), but it seems cleaner to do this in a followup if/as needed, as this requires some complexity wrt. rotation etc. 

Additionally, this PR contains:

- General cleanup and documentation improvements 
- Fix for display widths that are not a multiple of the alignment needed by the display (There are ePaper displays 122 pixel wide. Not sure why it couldn't be 120 or 128....), including a corresponding adjustment in the SSD1680 driver
- Make sure we get full stack traces for the new tests by forcing immediate display updates
